### PR TITLE
feat: CarvConfig struct + provider auto-detect + env API keys (#7)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -80,7 +80,6 @@ pub enum OutputFormat {
 }
 
 /// Resolved configuration combining CLI args with environment variables.
-#[derive(Debug)]
 pub struct CarvConfig {
     /// Task prompt.
     pub prompt: Option<String>,
@@ -136,6 +135,23 @@ impl CarvConfig {
             verbose: args.verbose,
             api_key,
         })
+    }
+}
+
+impl fmt::Debug for CarvConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CarvConfig")
+            .field("prompt", &self.prompt)
+            .field("model", &self.model)
+            .field("provider", &self.provider)
+            .field("print", &self.print)
+            .field("max_turns", &self.max_turns)
+            .field("output_format", &self.output_format)
+            .field("system_prompt", &self.system_prompt)
+            .field("disallowed_tools", &self.disallowed_tools)
+            .field("verbose", &self.verbose)
+            .field("api_key", &"<redacted>")
+            .finish()
     }
 }
 
@@ -274,6 +290,14 @@ mod tests {
     }
 
     #[test]
+    fn openai_auto_detect_o4() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "o4-mini"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::OpenAI);
+    }
+
+    #[test]
     fn unknown_model_without_provider_errors() {
         let args = CarvArgs::try_parse_from(["carv", "-m", "unknown-model"]).unwrap();
         let result = CarvConfig::from_args_and_env(args);
@@ -304,12 +328,17 @@ mod tests {
         let err = format!("{}", result.unwrap_err());
         assert!(err.contains("ANTHROPIC_API_KEY"), "error: {err}");
 
-        // 2. Auto-detect claude → Anthropic
+        // 2. Auto-detect claude- prefix → Anthropic
         unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
         let args = CarvArgs::try_parse_from(["carv", "-m", "claude-sonnet-4-20250514"]).unwrap();
         let config = CarvConfig::from_args_and_env(args).unwrap();
         assert_eq!(config.provider, Provider::Anthropic);
         assert_eq!(config.api_key, "test-key");
+
+        // 2b. Auto-detect anthropic/ prefix → Anthropic
+        let args = CarvArgs::try_parse_from(["carv", "-m", "anthropic/claude-sonnet"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::Anthropic);
 
         // 3. Explicit --provider overrides model-based auto-detect
         //    model=gpt-4o suggests OpenAI, but --provider anthropic overrides

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,8 @@
 // CLI argument parsing and configuration loading.
 
+use anyhow::{bail, Context, Result};
 use clap::Parser;
+use std::fmt;
 
 /// Main CLI configuration for carv.
 #[derive(Parser, Debug)]
@@ -57,6 +59,15 @@ pub enum Provider {
     OpenAI,
 }
 
+impl fmt::Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Provider::Anthropic => write!(f, "anthropic"),
+            Provider::OpenAI => write!(f, "openai"),
+        }
+    }
+}
+
 /// Output format for streaming results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum OutputFormat {
@@ -66,6 +77,85 @@ pub enum OutputFormat {
     Json,
     /// JSON lines stream.
     StreamJson,
+}
+
+/// Resolved configuration combining CLI args with environment variables.
+#[derive(Debug)]
+pub struct CarvConfig {
+    /// Task prompt.
+    pub prompt: Option<String>,
+    /// Model name.
+    pub model: Option<String>,
+    /// Resolved LLM provider.
+    pub provider: Provider,
+    /// Non-interactive output mode.
+    pub print: bool,
+    /// Maximum tool-use rounds.
+    pub max_turns: u32,
+    /// Output format.
+    pub output_format: OutputFormat,
+    /// Custom system prompt.
+    pub system_prompt: Option<String>,
+    /// Disallowed tools list.
+    pub disallowed_tools: Vec<String>,
+    /// Verbose debug output.
+    pub verbose: bool,
+    /// API key from environment.
+    pub api_key: String,
+}
+
+impl CarvConfig {
+    /// Resolve provider, read API key from env, and populate remaining fields.
+    pub fn from_args_and_env(args: CarvArgs) -> Result<Self> {
+        let provider = match args.provider {
+            Some(p) => p,
+            None => {
+                let model = args.model.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!("No model specified. Use -m <MODEL> or --provider <PROVIDER>.")
+                })?;
+                auto_detect_provider(model)?
+            }
+        };
+
+        let api_key = match provider {
+            Provider::Anthropic => std::env::var("ANTHROPIC_API_KEY")
+                .context("ANTHROPIC_API_KEY environment variable not set")?,
+            Provider::OpenAI => std::env::var("OPENAI_API_KEY")
+                .context("OPENAI_API_KEY environment variable not set")?,
+        };
+
+        Ok(CarvConfig {
+            prompt: args.prompt,
+            model: args.model,
+            provider,
+            print: args.print,
+            max_turns: args.max_turns,
+            output_format: args.output_format,
+            system_prompt: args.system_prompt,
+            disallowed_tools: args.disallowed_tools,
+            verbose: args.verbose,
+            api_key,
+        })
+    }
+}
+
+/// Auto-detect LLM provider from model name prefix.
+fn auto_detect_provider(model: &str) -> Result<Provider> {
+    if model.starts_with("claude-") || model.starts_with("anthropic/") {
+        Ok(Provider::Anthropic)
+    } else if model.starts_with("gpt-")
+        || model.starts_with("chatgpt-")
+        || model.starts_with("o1-")
+        || model.starts_with("o3-")
+        || model.starts_with("o4-")
+    {
+        Ok(Provider::OpenAI)
+    } else {
+        bail!(
+            "Cannot auto-detect provider for model '{}' — use --provider",
+            model
+        );
+    }
 }
 
 #[cfg(test)]
@@ -149,5 +239,84 @@ mod tests {
     fn model_option() {
         let args = CarvArgs::try_parse_from(["carv", "-m", "claude-sonnet-4-20250514"]).unwrap();
         assert_eq!(args.model.as_deref(), Some("claude-sonnet-4-20250514"));
+    }
+
+    // --- CarvConfig tests ---
+    //
+    // Note: Tests that manipulate ANTHROPIC_API_KEY are consolidated into a single
+    // test to avoid race conditions from parallel env var access (all share the same
+    // global state). OPENAI_API_KEY tests can be separate because they only set
+    // (never remove) that var, so they don't race.
+
+    #[test]
+    fn openai_auto_detect_gpt() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "gpt-4o"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::OpenAI);
+        assert_eq!(config.api_key, "test-key");
+    }
+
+    #[test]
+    fn openai_auto_detect_o3() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "o3-mini"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::OpenAI);
+    }
+
+    #[test]
+    fn openai_auto_detect_chatgpt() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "test-key") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "chatgpt-4o-latest"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::OpenAI);
+    }
+
+    #[test]
+    fn unknown_model_without_provider_errors() {
+        let args = CarvArgs::try_parse_from(["carv", "-m", "unknown-model"]).unwrap();
+        let result = CarvConfig::from_args_and_env(args);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("Cannot auto-detect provider"), "error: {err}");
+    }
+
+    #[test]
+    fn no_model_specified_errors() {
+        let args = CarvArgs::try_parse_from(["carv"]).unwrap();
+        let result = CarvConfig::from_args_and_env(args);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("No model specified"), "error: {err}");
+    }
+
+    /// Consolidated test for all ANTHROPIC_API_KEY-dependent scenarios.
+    /// Runs sequentially (within one test) to avoid races with other tests
+    /// that set/remove the same env var.
+    #[test]
+    fn anthropic_env_var_scenarios() {
+        // 1. Missing key → error
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "claude-sonnet-4-20250514"]).unwrap();
+        let result = CarvConfig::from_args_and_env(args);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("ANTHROPIC_API_KEY"), "error: {err}");
+
+        // 2. Auto-detect claude → Anthropic
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "test-key") };
+        let args = CarvArgs::try_parse_from(["carv", "-m", "claude-sonnet-4-20250514"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::Anthropic);
+        assert_eq!(config.api_key, "test-key");
+
+        // 3. Explicit --provider overrides model-based auto-detect
+        //    model=gpt-4o suggests OpenAI, but --provider anthropic overrides
+        let args =
+            CarvArgs::try_parse_from(["carv", "-m", "gpt-4o", "--provider", "anthropic"]).unwrap();
+        let config = CarvConfig::from_args_and_env(args).unwrap();
+        assert_eq!(config.provider, Provider::Anthropic);
+        assert_eq!(config.api_key, "test-key");
     }
 }


### PR DESCRIPTION
## Summary
- `CarvConfig` struct — resolved runtime config (10 fields including `api_key`)
- `from_args_and_env()` — resolves provider, reads API key from env, populates remaining fields
- Provider auto-detection: `claude-*` → Anthropic, `gpt-*/o1-*/o3-*/o4-*` → OpenAI
- API keys read from `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` env vars only

## Changes
| File | Lines |
|---|---|
| `src/cli/mod.rs` | +169 |

## Verification
- [x] `cargo build` ✅
- [x] `cargo test` (18 tests) ✅
- [x] `cargo clippy -- -D warnings` ✅
- [x] `cargo fmt -- --check` ✅
- [x] DoD review passed by rust-reviewer ✅

Closes #7