### PR TITLE
feat: add line cap gate to DoD checklist and routing model (#51)

### DIFF
--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -96,6 +96,20 @@ Before executing any task, classify it into one of five tiers. **This determines
    - Yes → **IMPLEMENT** (delegate to rust-coder/flash with scout results)
    - No → **DENSE** (handle directly with rust-expert/pro)
 
+### Scope vs. Line Cap Gate (MANDATORY — apply after classification, before delegation)
+
+Before delegating any IMPLEMENT, FORMULAIC, or DENSE task, **estimate whether the scope fits the line cap:**
+
+| Classification | Max diff lines | Action if exceeds |
+|---|---|---|
+| FORMULAIC | 150 | Split into separate PRs or escalate to ask user |
+| IMPLEMENT | 150 | Split into separate PRs or escalate to ask user |
+| DENSE | 100 | Split into separate PRs or escalate to ask user |
+
+**How to estimate:** Map the issue's feature list to Rust artifacts (one struct ≈ 15 lines, one trait ≈ 10 lines, one fn impl ≈ 10 lines, one test ≈ 10 lines, comments ≈ 10%). If the estimate exceeds the cap, **split before delegating** — do not delegate and hope.
+
+**Post-delegation check:** When the coder returns, immediately compare `git diff --stat` against the cap. If it exceeded, flag it. Either split the PR retroactively or note the violation in the DoD review.
+
 ### Simple Tasks (Answer Directly)
 - Keywords: `what is`, `how to`, `explain`, `show me`, `example`, `difference between`
 - Single concept explanations, quick references

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ DoD checklist:
 - [ ] Design doc (`docs/designs/2026-04-25-carv-design.md`) is still consistent with the changes (update it if needed)
 - [ ] All new code has tests (unit for tools, integration for flows, self-tests for carv itself)
 - [ ] Error handling follows the project philosophy (no panics in loop, tool errors returned as strings to LLM)
+- [ ] Diff does not exceed the line cap: ≤150 lines total for FORMULAIC/IMPLEMENT tasks, ≤100 lines for DENSE tasks. Split the PR if the scope is larger.
 
 **Reviewer handoff format:**
 


### PR DESCRIPTION
## Summary
Adds a PR diff line-cap guard in two places:

1. **DoD checklist** (`AGENTS.md`) — new item verifies the diff does not exceed 150 lines (formulaic/implement) or 100 lines (dense).
2. **Routing model** (`.opencode/agents/rust-expert.md`) — new mandatory `Scope vs. Line Cap Gate` section after classification, before delegation. Includes estimation heuristics (struct ≈ 15 lines, trait ≈ 10, test ≈ 10) and a post-delegation check against `git diff --stat`.

## Why
PR #51 (stream formatters) shipped 529 lines on a task labeled "~100 lines formulaic." No guard existed — the cap lived only in memory. This puts the check in two places: the reviewer's DoD verification (catches it after the fact) and the routing model's pre-delegation gate (catches it before tokens are spent).

## Changes
| File | Change |
|------|--------|
| `AGENTS.md` | +1 line in DoD checklist |
| `.opencode/agents/rust-expert.md` | +14 lines — new scope gate section |