### PR TITLE
feat: LlmProvider trait with boxed futures for object safety (#13)

### DIFF
--- a/docs/designs/2026-04-25-carv-design.md
+++ b/docs/designs/2026-04-25-carv-design.md
@@ -99,17 +99,21 @@ Provider auto-detection from model name (overridden by `--provider`):
 ## LLM Provider
 
 ```rust
+pub type LlmStream = Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>;
+
+pub type LlmStreamFuture<'a> = Pin<Box<dyn Future<Output = Result<LlmStream>> + Send + 'a>>;
+
 pub trait LlmProvider: Send + Sync {
     fn stream_chat(
         &self,
         messages: &[Message],
         tools: &[ToolDef],
         config: &RequestConfig,
-    ) -> impl Future<Output = Result<Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>>> + Send;
+    ) -> LlmStreamFuture<'_>;
 }
 ```
 
-No `async-trait` crate — uses native async fn in traits (Rust 1.75+, RPITIT).
+No `async-trait` crate — uses explicit boxed futures for object safety (so `Arc<dyn LlmProvider>` works in the agent loop). Same pattern as `StreamOutput`.
 
 ### RequestConfig
 

--- a/docs/designs/2026-04-25-carv-design.md
+++ b/docs/designs/2026-04-25-carv-design.md
@@ -105,7 +105,7 @@ pub trait LlmProvider: Send + Sync {
         messages: &[Message],
         tools: &[ToolDef],
         config: &RequestConfig,
-    ) -> impl Future<Output = Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>>> + Send;
+    ) -> impl Future<Output = Result<Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>>> + Send;
 }
 ```
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,3 +1,4 @@
 // Dual LLM provider: Anthropic SSE + OpenAI SSE.
 
+pub mod provider;
 pub mod types;

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -2,32 +2,34 @@
 //!
 //! Each provider (Anthropic, OpenAI) implements this trait to expose a
 //! unified streaming chat interface. The agent loop calls `stream_chat` and
-//! consumes `LlmEvent` items without knowing which backend is in use.
+//! consumes [`LlmEvent`] items without knowing which backend is in use.
 //!
 //! ## Design
-//! - Uses native async fn in traits (RPITIT, Rust 1.75+) — no `async-trait` crate.
-//! - Streams `LlmEvent` items; each provider translates its own SSE deltas
-//!   into this unified type.
+//! - Boxed-future return type (not RPITIT) keeps the trait **object-safe**,
+//!   so callers can hold `dyn LlmProvider` behind an `Arc`.  This is the same
+//!   pattern used by [`StreamOutput`](crate::stream::output::StreamOutput).
+//! - No `async-trait` crate — the boxed future is explicit.
+//! - The [`LlmStream`] and [`LlmStreamFuture`] aliases (from
+//!   [`crate::llm::types`]) keep the signature concise.
 //! - Errors are returned via `anyhow::Result` at both the stream and item levels.
 
-use std::future::Future;
-use std::pin::Pin;
-
-use anyhow::Result;
-use futures::Stream;
-
-use crate::llm::types::{LlmEvent, Message, RequestConfig, ToolDef};
+use crate::llm::types::{LlmStreamFuture, Message, RequestConfig, ToolDef};
 
 /// Abstract LLM provider capable of streaming chat completions with tool use.
 ///
 /// Implementations handle the provider-specific wire protocol (SSE event
 /// parsing, authentication, request formatting) and emit a unified stream
 /// of [`LlmEvent`] items.
+///
+/// ## Object safety
+/// This trait is object-safe — you can use `Arc<dyn LlmProvider>` in the
+/// agent loop. The boxed-future return type (instead of RPITIT `impl Future`)
+/// is what makes this possible.
 pub trait LlmProvider: Send + Sync {
     /// Start a streaming chat completion.
     ///
-    /// Returns a `Future` that resolves to a pinned, boxed, sendable stream of
-    /// `Result<LlmEvent>`. Each item in the stream represents a single delta:
+    /// Returns a [`LlmStreamFuture`] — a pinned, boxed, sendable future that
+    /// resolves to a [`LlmStream`]. Each item in the stream is a single delta:
     /// text tokens, thinking tokens, tool-use fragments, or terminal signals
     /// (`Done`, `Error`).
     fn stream_chat(
@@ -35,5 +37,5 @@ pub trait LlmProvider: Send + Sync {
         messages: &[Message],
         tools: &[ToolDef],
         config: &RequestConfig,
-    ) -> impl Future<Output = Result<Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>>> + Send;
+    ) -> LlmStreamFuture<'_>;
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -1,0 +1,39 @@
+//! `LlmProvider` trait — abstract interface for LLM backends.
+//!
+//! Each provider (Anthropic, OpenAI) implements this trait to expose a
+//! unified streaming chat interface. The agent loop calls `stream_chat` and
+//! consumes `LlmEvent` items without knowing which backend is in use.
+//!
+//! ## Design
+//! - Uses native async fn in traits (RPITIT, Rust 1.75+) — no `async-trait` crate.
+//! - Streams `LlmEvent` items; each provider translates its own SSE deltas
+//!   into this unified type.
+//! - Errors are returned via `anyhow::Result` at both the stream and item levels.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use anyhow::Result;
+use futures::Stream;
+
+use crate::llm::types::{LlmEvent, Message, RequestConfig, ToolDef};
+
+/// Abstract LLM provider capable of streaming chat completions with tool use.
+///
+/// Implementations handle the provider-specific wire protocol (SSE event
+/// parsing, authentication, request formatting) and emit a unified stream
+/// of [`LlmEvent`] items.
+pub trait LlmProvider: Send + Sync {
+    /// Start a streaming chat completion.
+    ///
+    /// Returns a `Future` that resolves to a pinned, boxed, sendable stream of
+    /// `Result<LlmEvent>`. Each item in the stream represents a single delta:
+    /// text tokens, thinking tokens, tool-use fragments, or terminal signals
+    /// (`Done`, `Error`).
+    fn stream_chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+        config: &RequestConfig,
+    ) -> impl Future<Output = Result<Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>>> + Send;
+}

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -8,6 +8,11 @@
 //! Types are prefixed `Llm*` (e.g. `LlmEvent`, `LlmUsage`) to avoid collision
 //! with output-level `StreamEvent` and `Usage` in `crate::stream::output`.
 
+use std::future::Future;
+use std::pin::Pin;
+
+use anyhow::Result;
+use futures::Stream;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -209,6 +214,24 @@ pub struct LlmUsage {
     )]
     pub cache_creation_tokens: Option<u32>,
 }
+
+// ---------------------------------------------------------------------------
+// Stream type aliases
+// ---------------------------------------------------------------------------
+
+/// Sendable, pinned stream of [`LlmEvent`] items.
+///
+/// Used as the return type of [`LlmProvider::stream_chat`]. Wrapping in `Pin`
+/// is required for async iteration, and boxing gives us `Sized` (necessary for
+/// returning from a trait method).
+pub type LlmStream = Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>;
+
+/// Sendable, pinned future resolving to a [`LlmStream`].
+///
+/// The `'a` lifetime corresponds to the borrow of the provider's `&self`.
+/// Using `dyn Future` (instead of `impl Future`) makes the
+/// [`LlmProvider`](crate::llm::provider::LlmProvider) trait object-safe.
+pub type LlmStreamFuture<'a> = Pin<Box<dyn Future<Output = Result<LlmStream>> + Send + 'a>>;
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -222,8 +222,8 @@ pub struct LlmUsage {
 /// Sendable, pinned stream of [`LlmEvent`] items.
 ///
 /// Used as the return type of [`LlmProvider::stream_chat`]. Wrapping in `Pin`
-/// is required for async iteration, and boxing gives us `Sized` (necessary for
-/// returning from a trait method).
+/// is required for async iteration, and boxing erases the concrete type so the
+/// trait remains object-safe.
 pub type LlmStream = Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>;
 
 /// Sendable, pinned future resolving to a [`LlmStream`].


### PR DESCRIPTION
## Summary
- Defines `LlmProvider` trait in `src/llm/provider.rs` — abstract interface for LLM backends
- Uses explicit boxed futures (NOT RPITIT) for object safety — `Arc<dyn LlmProvider>` works
- Streaming: `LlmStreamFuture<'_>` resolves to `LlmStream` (aliases keep signatures readable)
- Design doc synced: `StreamEvent` → `LlmEvent` + object-safety rationale

## Changes
- `src/llm/provider.rs` — new: `LlmProvider` trait with boxed-future return type + docs
- `src/llm/types.rs` — new: `LlmStream` and `LlmStreamFuture<'a>` type aliases
- `src/llm/mod.rs` — +1 line: `pub mod provider;`
- `docs/designs/2026-04-25-carv-design.md` — fix stale `StreamEvent` reference + update trait signature

## Design decisions
- Boxed futures (instead of RPITIT) keep the trait object-safe — same pattern as `StreamOutput` (#8)
- `LlmStream` / `LlmStreamFuture<'a>` aliases reduce verbosity at impl sites
- No `async-trait` crate

## Verification
- [x] `cargo build` passes
- [x] `cargo test` passes (59 tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] Diff: 84 lines (cap: 150 FORMULAIC)
- [x] rust-reviewer approved (2x)

Closes #13