### PR TITLE
ci: add GitHub Actions pipeline (build, test, clippy, fmt) (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+# CI pipeline for carv
+#
+# Triggers:
+#   - push to main
+#   - pull_request against all branches
+#
+# Jobs (4 gates in dependency order):
+#   1. build   — cargo build --verbose (must pass before other jobs)
+#   2. test    — cargo test --verbose  (depends on build)
+#   3. clippy  — cargo clippy -- -D warnings (depends on build)
+#   4. fmt     — cargo fmt -- --check (depends on build, runs parallel with test/clippy)
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: cargo build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --verbose
+
+  test:
+    name: cargo test
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --verbose
+
+  clippy:
+    name: cargo clippy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -- -D warnings
+
+  fmt:
+    name: cargo fmt
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt -- --check


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml` with 4 gated jobs that enforce the project's AGENTS.md quality gates automatically on every push to `main` and every PR.

## Workflow
```
build (cargo build --verbose)
  ├── test   (cargo test --verbose)
  ├── clippy (cargo clippy -- -D warnings)
  └── fmt    (cargo fmt -- --check)
```
- `build` must pass before `test`/`clippy`/`fmt` run (fast-fail)
- `test`, `clippy`, `fmt` run in parallel after build passes
- Uses `Swatinem/rust-cache@v2` for fast subsequent runs
- Stable Rust via `actions-rust-lang/setup-rust-toolchain@v1`

## Design decisions
- No `--frozen` — verifies `Cargo.lock` is up to date (binary crate policy)
- No `cargo-deny` (deferred to follow-up)
- Single `ubuntu-latest` + stable (no matrix needed at this stage)

## Verification
- [x] `cargo build` ✅
- [x] `cargo test` ✅
- [x] `cargo clippy` ✅
- [x] `cargo fmt` ✅
- [x] DoD review approved ✅

Closes #46