### PR TITLE
feat(tools): add Tool trait, ToolResult, ToolContext stub, and ToolFuture type alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,7 +269,7 @@ Format each entry as:
 - `clap` derive for CLI, `serde` derive for wire types
 - **Naming:** Project prefix is `Carv` not `Carve` — the crate is `carv`. Use `CarvArgs`, `CarvConfig`, etc.
 - `tracing` + `tracing-subscriber` for structured logging (not `println!`)
-- Trait methods return `impl Future<Output = Result<T>> + Send` (no boxed futures)
+- Trait methods use `impl Future<Output = Result<T>> + Send` where RPITIT works. Traits requiring `dyn` dispatch (object-safe) use boxed futures via `Pin<Box<dyn Future>>` with type aliases (e.g., `LlmStreamFuture`, `ToolFuture`).
 - Stream results via `Pin<Box<dyn Stream<Item = Result<T>> + Send>>`
 - Read-only vs. write tool distinction is informational only (shown in verbose/debug output)
 - Functions used only in `#[cfg(test)]` need `#[allow(dead_code)]` even with `pub(crate)` visibility. Clippy's `dead_code` lint doesn't count test code as usage. Add the attribute with a comment: `// Only called from tests.`

--- a/docs/designs/2026-04-25-carv-design.md
+++ b/docs/designs/2026-04-25-carv-design.md
@@ -183,15 +183,15 @@ pub trait Tool: Send + Sync {
     fn description(&self) -> &str;
     fn parameters_schema(&self) -> Value;  // JSON Schema
     fn is_read_only(&self) -> bool;        // informational, used in verbose output
-    fn execute(
-        &self,
+    fn execute<'a>(
+        &'a self,
         input: Value,
-        ctx: &ToolContext,
-    ) -> ToolFuture<'_>;  // boxed future for object safety (same pattern as LlmProvider)
+        ctx: &'a ToolContext,
+    ) -> ToolFuture<'a>;  // boxed future for object safety (same pattern as LlmProvider)
 }
 ```
 
-The boxed-future return type (`ToolFuture<'_>`) rather than RPITIT `impl Future` keeps the trait **object-safe**, so callers can hold `dyn Tool` in a registry (`Vec<Box<dyn Tool>>`). Same pattern as `LlmProvider`.
+The boxed-future return type (`ToolFuture<'a>`) rather than RPITIT `impl Future` keeps the trait **object-safe**, so callers can hold `dyn Tool` in a registry (`Vec<Box<dyn Tool>>`). Same pattern as `LlmProvider`.
 
 All tools auto-approved. `--disallowed-tools` removes tools from the registry before the LLM sees them. `is_read_only()` is informational — shown in `--verbose` output and stream-json events, but does not gate execution.
 

--- a/docs/designs/2026-04-25-carv-design.md
+++ b/docs/designs/2026-04-25-carv-design.md
@@ -187,9 +187,11 @@ pub trait Tool: Send + Sync {
         &self,
         input: Value,
         ctx: &ToolContext,
-    ) -> impl Future<Output = Result<ToolResult>> + Send;
+    ) -> ToolFuture<'_>;  // boxed future for object safety (same pattern as LlmProvider)
 }
 ```
+
+The boxed-future return type (`ToolFuture<'_>`) rather than RPITIT `impl Future` keeps the trait **object-safe**, so callers can hold `dyn Tool` in a registry (`Vec<Box<dyn Tool>>`). Same pattern as `LlmProvider`.
 
 All tools auto-approved. `--disallowed-tools` removes tools from the registry before the LLM sees them. `is_read_only()` is informational — shown in `--verbose` output and stream-json events, but does not gate execution.
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Each tool the LLM can invoke (read_file, execute_command, etc.) implements
 //! the [`Tool`] trait. The registry holds `Box<dyn Tool>` entries and applies
-//! deny-list filtering. See the [design doc](crate) for the full tool inventory.
+//! deny-list filtering. See the design doc for the full tool inventory.
 
 pub mod traits;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,1 +1,9 @@
-// Tool registry with deny-list filtering and auto-approved execution.
+//! Tool registry — [`Tool`] trait, [`ToolResult`], and re-exports.
+//!
+//! Each tool the LLM can invoke (read_file, execute_command, etc.) implements
+//! the [`Tool`] trait. The registry holds `Box<dyn Tool>` entries and applies
+//! deny-list filtering. See the [design doc](crate) for the full tool inventory.
+
+pub mod traits;
+
+pub use traits::{Tool, ToolContext, ToolFuture, ToolResult};

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -42,7 +42,7 @@ pub type ToolFuture<'a> = Pin<Box<dyn Future<Output = Result<ToolResult>> + Send
 /// signals that the tool encountered a recoverable problem (e.g. file not
 /// found, parse failure) — the LLM can use this information to retry or
 /// adjust its approach.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ToolResult {
     /// The output text returned to the LLM.
     pub content: String,
@@ -54,11 +54,30 @@ pub struct ToolResult {
     pub is_error: bool,
 }
 
+impl ToolResult {
+    /// Create a successful tool result.
+    pub fn ok(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: false,
+        }
+    }
+
+    /// Create a tool result representing a recoverable error.
+    pub fn error(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: true,
+        }
+    }
+}
+
 /// Context shared across all tool invocations.
 ///
 /// Carries project state such as the workspace root, LSP connection pool,
 /// and permission configuration. This is a stub that will be expanded in
 /// a future issue (#15).
+#[derive(Debug, Default)]
 pub struct ToolContext {}
 
 // ---------------------------------------------------------------------------
@@ -87,7 +106,7 @@ pub trait Tool: Send + Sync {
     }
 
     /// Execute the tool with the given input and context.
-    fn execute(&self, input: Value, ctx: &ToolContext) -> ToolFuture<'_>;
+    fn execute<'a>(&'a self, input: Value, ctx: &'a ToolContext) -> ToolFuture<'a>;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,10 +140,16 @@ mod tests {
             true
         }
 
-        fn execute(&self, _input: Value, _ctx: &ToolContext) -> ToolFuture<'_> {
+        fn execute<'a>(&'a self, _input: Value, _ctx: &'a ToolContext) -> ToolFuture<'a> {
             let content = self.content.clone();
             let is_error = self.should_error;
-            Box::pin(async move { Ok(ToolResult { content, is_error }) })
+            Box::pin(async move {
+                if is_error {
+                    Ok(ToolResult::error(content))
+                } else {
+                    Ok(ToolResult::ok(content))
+                }
+            })
         }
     }
 
@@ -134,7 +159,7 @@ mod tests {
             content: "hello".into(),
             should_error: false,
         };
-        let ctx = ToolContext {};
+        let ctx = ToolContext::default();
         let result = tool.execute(json!({}), &ctx).await.unwrap();
         assert_eq!(result.content, "hello");
         assert!(!result.is_error);
@@ -146,9 +171,10 @@ mod tests {
             content: "failed".into(),
             should_error: true,
         };
-        let ctx = ToolContext {};
+        let ctx = ToolContext::default();
         let result = tool.execute(json!({}), &ctx).await.unwrap();
         assert_eq!(result.content, "failed");
         assert!(result.is_error);
+        assert_eq!(result, ToolResult::error("failed"));
     }
 }

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -56,6 +56,7 @@ pub struct ToolResult {
 
 impl ToolResult {
     /// Create a successful tool result.
+    #[must_use]
     pub fn ok(content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
@@ -64,6 +65,7 @@ impl ToolResult {
     }
 
     /// Create a tool result representing a recoverable error.
+    #[must_use]
     pub fn error(content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
@@ -106,6 +108,7 @@ pub trait Tool: Send + Sync {
     }
 
     /// Execute the tool with the given input and context.
+    #[must_use]
     fn execute<'a>(&'a self, input: Value, ctx: &'a ToolContext) -> ToolFuture<'a>;
 }
 

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -1,0 +1,154 @@
+//! `Tool` trait — abstract interface for LLM-invokable tools.
+//!
+//! Each tool (e.g. `read_file`, `execute_command`) implements this trait to
+//! expose a name, description, JSON Schema parameters, and an async `execute`
+//! method. The agent loop calls `execute` and returns the [`ToolResult`] to
+//! the LLM without knowing which tool is in use.
+//!
+//! ## Design
+//! - Boxed-future return type (not RPITIT) keeps the trait **object-safe**,
+//!   so callers can hold `dyn Tool` in a registry (`Vec<Box<dyn Tool>>`).
+//!   This is the same pattern used by [`LlmProvider`](crate::llm::provider::LlmProvider).
+//! - No `async-trait` crate — the boxed future is explicit.
+//! - The [`ToolFuture`] type alias keeps the signature concise.
+//! - Errors are returned via `anyhow::Result`. Tool-level errors (permission
+//!   denied, file not found) are represented within [`ToolResult`] as
+//!   `is_error: true` so the LLM can observe and recover.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use anyhow::Result;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+/// Sendable, pinned future resolving to a [`ToolResult`].
+///
+/// The `'a` lifetime corresponds to the borrow of the tool's `&self` and
+/// `&ToolContext`.  Using `dyn Future` (instead of `impl Future`) makes the
+/// [`Tool`] trait object-safe.
+pub type ToolFuture<'a> = Pin<Box<dyn Future<Output = Result<ToolResult>> + Send + 'a>>;
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+/// Result of a single tool invocation.
+///
+/// `content` is a human-readable string returned to the LLM. `is_error`
+/// signals that the tool encountered a recoverable problem (e.g. file not
+/// found, parse failure) — the LLM can use this information to retry or
+/// adjust its approach.
+#[derive(Debug, Clone)]
+pub struct ToolResult {
+    /// The output text returned to the LLM.
+    pub content: String,
+    /// Whether the tool encountered an error.
+    ///
+    /// When `true`, `content` describes what went wrong. This is distinct
+    /// from returning an `Err` from [`Tool::execute`], which indicates an
+    /// unrecoverable failure (e.g. internal bug, configuration error).
+    pub is_error: bool,
+}
+
+/// Context shared across all tool invocations.
+///
+/// Carries project state such as the workspace root, LSP connection pool,
+/// and permission configuration. This is a stub that will be expanded in
+/// a future issue (#15).
+pub struct ToolContext {}
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// A tool that the LLM can invoke.
+///
+/// The `execute` method returns a boxed future (not RPITIT `impl Future`)
+/// to keep the trait object-safe, so callers can hold `Box<dyn Tool>` in a
+/// registry. This is the same pattern used by [`LlmProvider`](crate::llm::provider::LlmProvider).
+pub trait Tool: Send + Sync {
+    /// Short identifier shown to the LLM (e.g. `"read_file"`).
+    fn name(&self) -> &str;
+
+    /// Human-readable description sent as the tool's `description` field.
+    fn description(&self) -> &str;
+
+    /// JSON Schema describing the tool's input parameters.
+    fn parameters_schema(&self) -> Value;
+
+    /// Whether this tool only reads data (informational, used in verbose output).
+    /// Defaults to `false`.
+    fn is_read_only(&self) -> bool {
+        false
+    }
+
+    /// Execute the tool with the given input and context.
+    fn execute(&self, input: Value, ctx: &ToolContext) -> ToolFuture<'_>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    struct MockTool {
+        content: String,
+        should_error: bool,
+    }
+
+    impl Tool for MockTool {
+        fn name(&self) -> &str {
+            "mock_tool"
+        }
+
+        fn description(&self) -> &str {
+            "A mock tool for testing"
+        }
+
+        fn parameters_schema(&self) -> Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        fn is_read_only(&self) -> bool {
+            true
+        }
+
+        fn execute(&self, _input: Value, _ctx: &ToolContext) -> ToolFuture<'_> {
+            let content = self.content.clone();
+            let is_error = self.should_error;
+            Box::pin(async move { Ok(ToolResult { content, is_error }) })
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_tool_executes() {
+        let tool = MockTool {
+            content: "hello".into(),
+            should_error: false,
+        };
+        let ctx = ToolContext {};
+        let result = tool.execute(json!({}), &ctx).await.unwrap();
+        assert_eq!(result.content, "hello");
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn mock_tool_reports_error() {
+        let tool = MockTool {
+            content: "failed".into(),
+            should_error: true,
+        };
+        let ctx = ToolContext {};
+        let result = tool.execute(json!({}), &ctx).await.unwrap();
+        assert_eq!(result.content, "failed");
+        assert!(result.is_error);
+    }
+}


### PR DESCRIPTION
## Summary
- Defines the object-safe `Tool` trait with boxed futures (matching `LlmProvider` pattern for `dyn Tool` in registry)
- `ToolResult` struct with `content: String` + `is_error: bool` for LLM-recoverable failures
- `ToolContext` stub struct (to be expanded in #15)
- `ToolFuture<'a>` type alias to keep signatures clean
- Updates design doc and AGENTS.md to document the boxed-future exception for object-safe traits

**Closes #14**

## Changes
| File | Change |
|------|--------|
| `src/tools/traits.rs` | New: `Tool`, `ToolResult`, `ToolContext`, `ToolFuture`, 2 tests |
| `src/tools/mod.rs` | Add `pub mod traits` + re-exports |
| `AGENTS.md` | Line 272: document boxed-future exception for `dyn` dispatch |
| `docs/designs/2026-04-25-carv-design.md` | Updated `execute()` signature to `ToolFuture<'_>` |

## Verification
- [x] `cargo build` — ✅
- [x] `cargo test` — 80 tests ✅
- [x] `cargo clippy -- -D warnings` — ✅
- [x] `cargo fmt -- --check` — ✅