### PR TITLE
feat(tools): expand ToolContext + add ToolRegistry with deny-list filtering

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,6 +4,8 @@
 //! the [`Tool`] trait. The registry holds `Box<dyn Tool>` entries and applies
 //! deny-list filtering. See the design doc for the full tool inventory.
 
+pub mod registry;
 pub mod traits;
 
+pub use registry::ToolRegistry;
 pub use traits::{Tool, ToolContext, ToolFuture, ToolResult};

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1,0 +1,238 @@
+//! Tool registry — [`ToolRegistry`] with deny-list filtering.
+//!
+//! Tools are registered by name, filtered by `--disallowed-tools`, and exposed
+//! to the LLM provider as a list of [`ToolDef`] structs for API requests.
+//!
+//! The registry stores tools in an `Arc<Mutex<HashMap<String, Arc<dyn Tool>>>>`
+//! so it can be shared across threads (agent loop + LSP callbacks).  Deny-listed
+//! tools are kept in the map but hidden from [`tool_defs`] — they can be
+//! re-enabled by removing their name from the deny set.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use tracing::debug;
+
+use crate::llm::types::ToolDef;
+use crate::tools::traits::Tool;
+
+// ---------------------------------------------------------------------------
+// ToolRegistry
+// ---------------------------------------------------------------------------
+
+/// Registry of LLM-invokable tools with deny-list filtering.
+///
+/// Tools are registered by name, filtered by `--disallowed-tools`, and exposed
+/// to the LLM provider as a list of [`ToolDef`] structs for API requests.
+pub struct ToolRegistry {
+    /// All registered tools, keyed by name. Wrapped in `Arc<Mutex<>>` for
+    /// thread-safe access from the agent loop and LSP callbacks.
+    tools: Arc<Mutex<HashMap<String, Arc<dyn Tool>>>>,
+    /// Set of tool names to hide from the LLM.
+    disallowed: HashSet<String>,
+}
+
+impl std::fmt::Debug for ToolRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let tools = self.tools.lock().expect("tool registry lock poisoned");
+        let names: Vec<&str> = tools.keys().map(|s| s.as_str()).collect();
+        f.debug_struct("ToolRegistry")
+            .field("tool_count", &names.len())
+            .field("visible_count", &self.visible_count())
+            .field("disallowed", &self.disallowed)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ToolRegistry {
+    /// Create a new registry, filtering out disallowed tools.
+    ///
+    /// Tools whose names appear in `disallowed` are excluded from the LLM-facing
+    /// tool list but are still stored internally so they can be re-enabled later.
+    pub fn new(tools: Vec<Box<dyn Tool>>, disallowed: Vec<String>) -> Self {
+        let mut map: HashMap<String, Arc<dyn Tool>> = HashMap::new();
+        for tool in tools {
+            let name = tool.name().to_owned();
+            debug!(tool = %name, "registering tool");
+            map.insert(name, Arc::from(tool));
+        }
+
+        let disallowed: HashSet<String> = disallowed.into_iter().collect();
+
+        if !disallowed.is_empty() {
+            debug!(?disallowed, "tools hidden from LLM via deny-list");
+        }
+
+        ToolRegistry {
+            tools: Arc::new(Mutex::new(map)),
+            disallowed,
+        }
+    }
+
+    /// Look up a tool by name for dispatch.
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools
+            .lock()
+            .expect("tool registry lock poisoned")
+            .get(name)
+            .cloned()
+    }
+
+    /// List all tool definitions visible to the LLM (disallowed tools excluded).
+    pub fn tool_defs(&self) -> Vec<ToolDef> {
+        let tools = self.tools.lock().expect("tool registry lock poisoned");
+        tools
+            .iter()
+            .filter(|(name, _)| !self.disallowed.contains(name.as_str()))
+            .map(|(_, tool)| ToolDef {
+                name: tool.name().to_owned(),
+                description: tool.description().to_owned(),
+                input_schema: tool.parameters_schema(),
+            })
+            .collect()
+    }
+
+    /// Number of tools visible to the LLM (after deny-list filtering).
+    pub fn visible_count(&self) -> usize {
+        let tools = self.tools.lock().expect("tool registry lock poisoned");
+        tools
+            .keys()
+            .filter(|name| !self.disallowed.contains(name.as_str()))
+            .count()
+    }
+
+    /// Register a new tool (for testing / dynamic extension).
+    pub fn register(&mut self, tool: Box<dyn Tool>) {
+        let name = tool.name().to_owned();
+        debug!(tool = %name, "registering tool (dynamic)");
+        self.tools
+            .lock()
+            .expect("tool registry lock poisoned")
+            .insert(name, Arc::from(tool));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::traits::{ToolContext, ToolFuture, ToolResult};
+    use serde_json::json;
+
+    /// Minimal stub tool for registry tests.
+    ///
+    /// Satisfies the full [`Tool`] trait contract but the `execute` method is
+    /// never invoked by registry-only tests (register/get/filter).
+    struct StubTool {
+        name: &'static str,
+        desc: &'static str,
+        schema: serde_json::Value,
+        readonly: bool,
+    }
+
+    impl Tool for StubTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn description(&self) -> &str {
+            self.desc
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            self.schema.clone()
+        }
+        fn is_read_only(&self) -> bool {
+            self.readonly
+        }
+        fn execute<'a>(
+            &'a self,
+            _input: serde_json::Value,
+            _ctx: &'a ToolContext,
+        ) -> ToolFuture<'a> {
+            Box::pin(async move { Ok(ToolResult::ok("stub")) })
+        }
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let mut reg = ToolRegistry::new(vec![], vec![]);
+        let tool = Box::new(StubTool {
+            name: "read",
+            desc: "Reads files",
+            schema: json!({}),
+            readonly: true,
+        });
+        reg.register(tool);
+        assert!(reg.get("read").is_some());
+        assert!(reg.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn deny_list_filters_tools() {
+        let t1 = Box::new(StubTool {
+            name: "read",
+            desc: "r",
+            schema: json!({}),
+            readonly: true,
+        });
+        let t2 = Box::new(StubTool {
+            name: "write",
+            desc: "w",
+            schema: json!({}),
+            readonly: false,
+        });
+        let t3 = Box::new(StubTool {
+            name: "exec",
+            desc: "e",
+            schema: json!({}),
+            readonly: false,
+        });
+
+        let reg = ToolRegistry::new(vec![t1, t2, t3], vec!["exec".to_string()]);
+
+        assert_eq!(reg.visible_count(), 2);
+        let defs = reg.tool_defs();
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"read"));
+        assert!(names.contains(&"write"));
+        assert!(!names.contains(&"exec"));
+    }
+
+    #[test]
+    fn tool_defs_include_schemas() {
+        let schema = json!({"type": "object", "properties": {"path": {"type": "string"}}});
+        let tool = Box::new(StubTool {
+            name: "cat",
+            desc: "view file",
+            schema: schema.clone(),
+            readonly: true,
+        });
+        let reg = ToolRegistry::new(vec![tool], vec![]);
+        let defs = reg.tool_defs();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name, "cat");
+        assert_eq!(defs[0].input_schema, schema);
+    }
+
+    #[test]
+    fn empty_registry_is_valid() {
+        let reg = ToolRegistry::new(vec![], vec![]);
+        assert_eq!(reg.visible_count(), 0);
+        assert!(reg.tool_defs().is_empty());
+    }
+
+    #[test]
+    fn disallowed_tool_not_in_defs() {
+        let tool = Box::new(StubTool {
+            name: "danger",
+            desc: "do not use",
+            schema: json!({}),
+            readonly: false,
+        });
+        let reg = ToolRegistry::new(vec![tool], vec!["danger".to_string()]);
+        assert_eq!(reg.visible_count(), 0);
+        assert!(reg.tool_defs().is_empty());
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1,12 +1,6 @@
-//! Tool registry — [`ToolRegistry`] with deny-list filtering.
+//! Thread-safe tool registry with deny-list filtering.
 //!
-//! Tools are registered by name, filtered by `--disallowed-tools`, and exposed
-//! to the LLM provider as a list of [`ToolDef`] structs for API requests.
-//!
-//! The registry stores tools in an `Arc<Mutex<HashMap<String, Arc<dyn Tool>>>>`
-//! so it can be shared across threads (agent loop + LSP callbacks).  Deny-listed
-//! tools are kept in the map but hidden from [`tool_defs`] — they can be
-//! re-enabled by removing their name from the deny set.
+//! See [`ToolRegistry`] for details.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -25,8 +19,15 @@ use crate::tools::traits::Tool;
 /// Tools are registered by name, filtered by `--disallowed-tools`, and exposed
 /// to the LLM provider as a list of [`ToolDef`] structs for API requests.
 pub struct ToolRegistry {
-    /// All registered tools, keyed by name. Wrapped in `Arc<Mutex<>>` for
-    /// thread-safe access from the agent loop and LSP callbacks.
+    /// All registered tools, keyed by name.
+    ///
+    /// Wrapped in `Arc<Mutex<>>` so that `&self` methods (`get`, `tool_defs`,
+    /// `visible_count`) can be called concurrently from multiple async tasks
+    /// (agent loop, LSP callbacks).  `register()` takes `&mut self` because
+    /// dynamic tool registration is an infrequent mutation — callers that
+    /// need shared mutable access can wrap the entire registry in
+    /// `Arc<Mutex<ToolRegistry>>`, and the inner `Mutex` still allows
+    /// concurrent reads when the outer lock is held for writes.
     tools: Arc<Mutex<HashMap<String, Arc<dyn Tool>>>>,
     /// Set of tool names to hide from the LLM.
     disallowed: HashSet<String>,
@@ -35,10 +36,13 @@ pub struct ToolRegistry {
 impl std::fmt::Debug for ToolRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let tools = self.tools.lock().expect("tool registry lock poisoned");
-        let names: Vec<&str> = tools.keys().map(|s| s.as_str()).collect();
+        let visible = tools
+            .keys()
+            .filter(|name| !self.disallowed.contains(name.as_str()))
+            .count();
         f.debug_struct("ToolRegistry")
-            .field("tool_count", &names.len())
-            .field("visible_count", &self.visible_count())
+            .field("tool_count", &tools.len())
+            .field("visible_count", &visible)
             .field("disallowed", &self.disallowed)
             .finish_non_exhaustive()
     }
@@ -81,7 +85,7 @@ impl ToolRegistry {
     /// List all tool definitions visible to the LLM (disallowed tools excluded).
     pub fn tool_defs(&self) -> Vec<ToolDef> {
         let tools = self.tools.lock().expect("tool registry lock poisoned");
-        tools
+        let mut defs: Vec<ToolDef> = tools
             .iter()
             .filter(|(name, _)| !self.disallowed.contains(name.as_str()))
             .map(|(_, tool)| ToolDef {
@@ -89,7 +93,9 @@ impl ToolRegistry {
                 description: tool.description().to_owned(),
                 input_schema: tool.parameters_schema(),
             })
-            .collect()
+            .collect();
+        defs.sort_by(|a, b| a.name.cmp(&b.name));
+        defs
     }
 
     /// Number of tools visible to the LLM (after deny-list filtering).
@@ -101,7 +107,7 @@ impl ToolRegistry {
             .count()
     }
 
-    /// Register a new tool (for testing / dynamic extension).
+    /// Register a new tool dynamically.
     pub fn register(&mut self, tool: Box<dyn Tool>) {
         let name = tool.name().to_owned();
         debug!(tool = %name, "registering tool (dynamic)");

--- a/src/tools/traits.rs
+++ b/src/tools/traits.rs
@@ -16,7 +16,9 @@
 //!   `is_error: true` so the LLM can observe and recover.
 
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use serde_json::Value;
@@ -76,11 +78,14 @@ impl ToolResult {
 
 /// Context shared across all tool invocations.
 ///
-/// Carries project state such as the workspace root, LSP connection pool,
-/// and permission configuration. This is a stub that will be expanded in
-/// a future issue (#15).
-#[derive(Debug, Default)]
-pub struct ToolContext {}
+/// Carries project state accessible to every tool's `execute` method.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    /// Absolute path to the project root directory.
+    pub workspace_root: PathBuf,
+    /// Shared anchor state for hash-anchored line referencing.
+    pub anchor_state: Arc<Mutex<crate::hashing::state::AnchorState>>,
+}
 
 // ---------------------------------------------------------------------------
 // Trait
@@ -120,6 +125,7 @@ pub trait Tool: Send + Sync {
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::sync::{Arc, Mutex};
 
     struct MockTool {
         content: String,
@@ -156,13 +162,21 @@ mod tests {
         }
     }
 
+    /// Minimal `ToolContext` for use in tests where the filesystem is not relevant.
+    fn test_context() -> ToolContext {
+        ToolContext {
+            workspace_root: PathBuf::from("/tmp/test"),
+            anchor_state: Arc::new(Mutex::new(crate::hashing::state::AnchorState::new())),
+        }
+    }
+
     #[tokio::test]
     async fn mock_tool_executes() {
         let tool = MockTool {
             content: "hello".into(),
             should_error: false,
         };
-        let ctx = ToolContext::default();
+        let ctx = test_context();
         let result = tool.execute(json!({}), &ctx).await.unwrap();
         assert_eq!(result.content, "hello");
         assert!(!result.is_error);
@@ -174,7 +188,7 @@ mod tests {
             content: "failed".into(),
             should_error: true,
         };
-        let ctx = ToolContext::default();
+        let ctx = test_context();
         let result = tool.execute(json!({}), &ctx).await.unwrap();
         assert_eq!(result.content, "failed");
         assert!(result.is_error);


### PR DESCRIPTION
## Summary
- Expands `ToolContext` from empty stub to struct with `workspace_root` + `Arc<Mutex<AnchorState>>`
- Adds `ToolRegistry` with thread-safe tool storage, deny-list filtering, and LLM-facing `tool_defs()`
- Deny-listed tools stay stored internally so they can be re-enabled without re-registration

**Closes #15**

## Changes
| File | Change |
|------|--------|
| `src/tools/traits.rs` | ToolContext expanded: `workspace_root: PathBuf`, `anchor_state: Arc<Mutex<AnchorState>>` |
| `src/tools/registry.rs` | New: `ToolRegistry` with `new()`, `get()`, `tool_defs()`, `register()`, `visible_count()` |
| `src/tools/mod.rs` | Re-exports `ToolRegistry` |

## Verification
- [x] `cargo build` — ✅
- [x] `cargo test` — 85 tests ✅ (5 new)
- [x] `cargo clippy -- -D warnings` — ✅
- [x] `cargo fmt -- --check` — ✅

## Design Notes
- `Arc<Mutex<HashMap>>` for shared access across agent loop + LSP callbacks
- `Arc<dyn Tool>` so `get()` returns cloned handles for concurrent use
- Manual `Debug` impl avoids requiring `dyn Tool: Debug`
- `register()` takes `&mut self` — intentional: dynamic registration is a mutation
- No new dependencies