### PR TITLE
feat: deepen reviewer and coder quality instincts (#64)

### DIFF
--- a/.opencode/config/agent-metadata.json
+++ b/.opencode/config/agent-metadata.json
@@ -16,12 +16,12 @@
     "rust-coder": {
       "type": "general",
       "path": ".opencode/subagents/rust-coder.md",
-      "description": "Rust code generation specialist with cargo verification"
+      "description": "Rust code generation specialist. Follows project serde conventions, writes one test per tagged-enum variant, avoids redundant annotations, and verifies with cargo."
     },
     "rust-reviewer": {
       "type": "general",
       "path": ".opencode/subagents/rust-reviewer.md",
-      "description": "Rust code review specialist for safety and performance"
+      "description": "Rust code review specialist. Flags redundant serde annotations, missing derives, untested enum variants, and wire format mismatches. Checks test coverage per public type and spec compliance before verifying the DoD checklist."
     },
     "rust-tester": {
       "type": "general",

--- a/.opencode/subagents/rust-coder.md
+++ b/.opencode/subagents/rust-coder.md
@@ -118,6 +118,23 @@ If `cargo clippy` fails, fix warnings. If `cargo test` fails, fix tests or the c
 - Avoid unnecessary clones in hot paths
 - Zero-copy parsing where feasible (tree-sitter byte ranges)
 
+### Serde & Wire Types
+
+- Serialization-only types: derive `Serialize` only (request types). Deserialization-only: `Deserialize` only (SSE events). Don't derive both unless needed.
+- Wire format accuracy: every `#[serde(rename)]` must quote the literal key from the API reference. No guessing.
+- `#[serde(default)]` is only needed on non-`Option` fields with sensible defaults. On `Option<T>` it's redundant (serde defaults Option to None).
+- `#[serde(flatten)]`: always include a round-trip test proving the wire shape is correct.
+- `#[serde(untagged)]`: variant order matters. The first variant that deserializes wins. Document the order choice in a comment.
+- Tagged enums (`#[serde(tag = "type")]`): every variant gets at least one deserialization test.
+
+### Test Coverage Standards
+
+- **Tagged enums**: at least one deserialization test per variant.
+- **Optional fields**: at least one test with all skippable fields absent.
+- **Trickiest wire feature**: identify and test the most unusual field placement (e.g., fields at the top level vs. nested).
+- **Edge cases**: empty arrays, null values, missing required fields, unknown variants.
+- **Round-trip**: serde types that are both serialized and deserialized need a `serde_json::from_str(serde_json::to_string(&x).unwrap()).unwrap()` round-trip test.
+
 ### Tree-sitter Integration
 - Handle parse failures gracefully (fall back to raw read)
 - Cache parsed trees per-file, invalidate on modification

--- a/.opencode/subagents/rust-reviewer.md
+++ b/.opencode/subagents/rust-reviewer.md
@@ -70,6 +70,23 @@ This subagent is invoked by `rust-expert` for:
 - [ ] **DRY**: No duplicated logic
 - [ ] **Module structure**: Clear separation of concerns
 
+### 7. Serde & Wire Types
+
+- [ ] **No redundant `#[serde(default)]`**: Serde already treats `Option<T>` as `None` when the field is absent. The annotation is a no-op on `Option` fields — flag it.
+- [ ] **Wire format accuracy**: Every `#[serde(rename)]` and `#[serde(rename_all)]` must match the actual wire-level key in the provider's API reference. Verify against the spec or API docs.
+- [ ] **Variant coverage**: Every variant in a `#[serde(tag = "type")]` enum must have at least one deserialization test. No variant is "too simple to test" — bugs hide in the untested.
+- [ ] **Absent-field round-trip**: When a type is reused for deserialization in a different context (e.g., `ContentBlock` used in both request building and SSE parsing), verify that absent optional fields (`cache_control`, `stop_sequences`, etc.) deserialize without error.
+- [ ] **`#[rustfmt::skip]`**: Questioned on every occurrence. The reviewer must ask: is the skip shrinking a 3-line enum into 1 line for readability, or is it hiding sloppy formatting? No skip without a comment.
+- [ ] **`#[serde(flatten)]` correctness**: Verify the flatten target's wire shape matches expectations with a round-trip test. Flattened structs can silently swallow misnamed fields.
+- [ ] **`#[serde(untagged)]` ordering**: Variants are tried in declaration order. For `String` before `Vec<ContentBlock>`, a string will never accidentally match the vec variant — verify the order is safe.
+- [ ] **Derive hygiene**: Types used in test assertions need `PartialEq`. Types stored in collections need `Eq`, `Hash`. Types logged or passed across threads need `Debug`. Missing derives cause downstream pain.
+
+### 8. Test Coverage Depth (beyond "tests exist")
+
+- [ ] **No untested public items**: Cross-reference `pub` types/functions against the test module. Every `pub fn`, `pub struct`, and `pub enum` variant must appear in at least one test. Flag any with zero coverage.
+- [ ] **The trickiest wire feature**: Identify the most unusual field in the API format and test it specifically (e.g., Anthropic's top-level `usage` in `message_delta`, not nested inside `delta`).
+- [ ] **Edge cases**: Empty arrays, null fields, missing required fields, unknown variants.
+
 ## Review Output Format
 
 ```markdown

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,27 @@ Tree-sitter query files (`.scm`) are **not Rust** — they are S-expression patt
 
 These files are a distinct review category from Rust code. Don't review them like logic — review them like templates against a known grammar.
 
+## Review Depth Standards
+
+The reviewer (rust-reviewer) must go beyond mechanical DoD checks. These apply to all PRs:
+
+### For all PRs
+- Read every line of the diff. Do not skim.
+- Flag: redundant `#[serde(default)]` on `Option<T>` fields.
+- Flag: missing `PartialEq`/`Debug` derives on types used in test assertions or stored in collections.
+- Flag: `#[rustfmt::skip]` without a comment explaining why.
+- Map every public type/function to its covering test(s); flag any with zero coverage.
+
+### For serde-heavy PRs
+- Verify every `#[serde(rename)]` matches the actual wire-level key in the provider's API reference.
+- Verify one deserialization test per tagged-enum variant.
+- Verify round-trip with absent optional fields.
+- Verify `#[serde(untagged)]` variant order is safe.
+
+### For provider/wire-type PRs
+- Cross-reference request/response fields against the provider's API reference.
+- Test the trickiest wire format feature (e.g., Anthropic's top-level `usage` in `message_delta`, not nested inside `delta`).
+
 ## Dependencies to Know
 
 - `tokio` — multi-threaded runtime, process spawning, channels


### PR DESCRIPTION
## Summary
- Adds **Serde & Wire Types** checklist (7 items) to `rust-reviewer.md` — flags redundant annotations, wire format mismatches, untested enum variants, `#[rustfmt::skip]` abuse
- Adds **Test Coverage Depth** checklist to `rust-reviewer.md` — public item coverage mapping, trickiest wire feature testing, edge cases
- Adds **serde guidelines + test coverage standards** to `rust-coder.md` — `#[serde(default)]` awareness, tagged-enum test rules, round-trip requirements
- Adds **Review Depth Standards** section to `AGENTS.md` — removes the "mechanical review only until Milestone 3+" constraint; review depth active from Milestone 2 onward
- Updates `agent-metadata.json` descriptions for rust-reviewer and rust-coder

## Why
The reviewer for #16 (Anthropic wire types) did only mechanical DoD checks despite the PR being 100% serde/wire types. Several real issues went unflagged:
- Redundant `#[serde(default)]` on `Option` fields
- No deserialization test for `message_delta` (the trickiest SSE variant)
- Gaps in variant coverage (4 of 8 SSE variants untested)

Root cause: the reviewer's prompt covered memory safety, async, error handling — but had zero content about serde or wire types. This fixes that.

## Checklist
- [x] `cargo build` / `cargo test` / `cargo clippy` / `cargo fmt` all pass
- [x] No Rust code changes — zero risk of runtime regressions
- [x] No new dependencies
- [x] Rust-reviewer approved

Closes #64