### PR TITLE
feat(llm): Anthropic SSE streaming provider with tool-use delta accumulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "process", "time", "fs", "sync"] }
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 reqwest-eventsource = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -1,5 +1,15 @@
 //! Anthropic `/v1/messages` API — request (Serialize), SSE (Deserialize), tool mapping.
-use crate::llm::types::{ContentBlock, Message, ToolDef};
+use std::collections::HashMap;
+use std::time::Duration;
+
+use futures::StreamExt;
+use reqwest_eventsource::{retry::RetryPolicy, Event, EventSource};
+
+use crate::llm::provider::LlmProvider;
+use crate::llm::types::{
+    ContentBlock, ContentType, LlmEvent, LlmStream, LlmStreamFuture, LlmUsage, Message,
+    RequestConfig, Role, ToolDef,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
@@ -39,6 +49,10 @@ pub struct AnthropicUsageSummary {
     pub input_tokens: Option<u32>,
     #[serde(default)]
     pub output_tokens: Option<u32>,
+    #[serde(default)]
+    pub cache_read_input_tokens: Option<u32>,
+    #[serde(default)]
+    pub cache_creation_input_tokens: Option<u32>,
 }
 #[derive(Debug, Clone, Deserialize)]
 pub struct AnthropicMessageStart {
@@ -88,6 +102,454 @@ pub enum AnthropicSseEvent {
 pub fn to_anthropic_tools(tools: &[ToolDef]) -> Vec<serde_json::Value> {
     tools.iter().map(|t| serde_json::json!({"name": t.name, "description": t.description, "input_schema": t.input_schema})).collect()
 }
+
+// ---------------------------------------------------------------------------
+// Retry policy — we handle retry in the agent loop, not at the SSE layer
+// ---------------------------------------------------------------------------
+
+/// Retry policy that never retries. The agent loop handles retry with
+/// exponential backoff; reconnecting at the SSE layer would create
+/// duplicate requests.
+struct NoRetry;
+
+impl RetryPolicy for NoRetry {
+    fn retry(
+        &self,
+        _error: &reqwest_eventsource::Error,
+        _last: Option<(usize, Duration)>,
+    ) -> Option<Duration> {
+        None
+    }
+
+    fn set_reconnection_time(&mut self, _duration: Duration) {}
+}
+
+// ---------------------------------------------------------------------------
+// SSE → LlmEvent state machine types
+// ---------------------------------------------------------------------------
+
+/// Per-block tracking during SSE streaming.
+///
+/// Anthropic content blocks arrive in three phases: `content_block_start`
+/// (type + metadata), `content_block_delta` (payload chunks), and
+/// `content_block_stop` (block finished). For `tool_use` blocks, partial
+/// JSON fragments are accumulated and then parsed into the complete
+/// `serde_json::Value` on `content_block_stop`.
+#[derive(Debug)]
+enum BlockState {
+    Text,
+    Thinking,
+    ToolUse {
+        id: String,
+        name: String,
+        json_acc: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// AnthropicProvider
+// ---------------------------------------------------------------------------
+
+static ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+
+/// Anthropic `/v1/messages` SSE client implementing [`LlmProvider`].
+///
+/// Streams chat completions with tool use, prompt caching, and extended
+/// thinking support. Translates Anthropic's SSE wire protocol into the
+/// unified [`LlmEvent`] stream consumed by the agent loop.
+pub struct AnthropicProvider {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl AnthropicProvider {
+    pub fn new(api_key: String, model: String) -> Self {
+        Self {
+            api_key,
+            model,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the system prompt from the messages list for Anthropic's
+/// top-level `system` field.
+///
+/// Anthropic places the system prompt in a separate `system` field on the
+/// request, not in the `messages` array. This helper locates the first
+/// `Role::System` message, removes it, and converts it to the wire format.
+fn extract_system(mut messages: Vec<Message>) -> (Option<AnthropicSystem>, Vec<Message>) {
+    if let Some(idx) = messages.iter().position(|m| m.role == Role::System) {
+        let system_msg = messages.remove(idx);
+        // Use String variant for single text block, Blocks for everything else
+        let system = system_msg.content;
+        if system.len() == 1 {
+            if let ContentType::Text { text } = &system[0].content {
+                return (Some(AnthropicSystem::String(text.clone())), messages);
+            }
+        }
+        (Some(AnthropicSystem::Blocks(system)), messages)
+    } else {
+        (None, messages)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LlmProvider implementation
+// ---------------------------------------------------------------------------
+
+impl LlmProvider for AnthropicProvider {
+    fn stream_chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDef],
+        config: &RequestConfig,
+    ) -> LlmStreamFuture<'_> {
+        let api_key = self.api_key.clone();
+        let model = self.model.clone();
+        let client = self.client.clone();
+        let messages = messages.to_vec();
+        let tools = tools.to_vec();
+        let config = config.clone();
+
+        Box::pin(async move {
+            // Separate system prompt for Anthropic top-level `system` field
+            let (system, messages) = extract_system(messages);
+
+            // Build extended thinking config if enabled
+            let thinking = if config.thinking {
+                Some(AnthropicThinking {
+                    thinking_type: "enabled".to_string(),
+                    budget_tokens: config.thinking_budget.unwrap_or(1024),
+                })
+            } else {
+                None
+            };
+
+            let request = AnthropicRequest {
+                model: model.clone(),
+                max_tokens: config.max_tokens,
+                messages,
+                system,
+                tools: to_anthropic_tools(&tools),
+                stream: true,
+                thinking,
+                temperature: config.temperature,
+                top_p: config.top_p,
+                stop_sequences: config.stop_sequences.clone(),
+            };
+
+            // Build the HTTP request
+            let builder = client
+                .post(format!("{}/v1/messages", ANTHROPIC_BASE_URL))
+                .header("x-api-key", &api_key)
+                .header("anthropic-version", "2023-06-01")
+                .json(&request);
+
+            // EventSource adds Accept: text/event-stream and handles SSE parsing
+            let mut es = EventSource::new(builder)
+                .map_err(|e| anyhow::anyhow!("Failed to create SSE event source: {e:?}"))?;
+            es.set_retry_policy(Box::new(NoRetry));
+
+            // State machine: SSE events → LlmEvent stream
+            //
+            // We use futures::stream::unfold to drive the EventSource and
+            // map raw SSE events into LlmEvent items.  Intermediate events
+            // (like `content_block_start` that just record metadata, or
+            // `ping`) loop without yielding until a user-visible event is
+            // ready.
+            use futures::stream;
+
+            let llm_stream = stream::unfold(
+                (
+                    es,
+                    HashMap::<u32, BlockState>::new(),
+                    None,  // input_tokens
+                    None,  // output_tokens
+                    None,  // cache_read
+                    None,  // cache_creation
+                    false, // done
+                ),
+                move |(
+                    mut es,
+                    mut blocks,
+                    mut input_tok,
+                    mut output_tok,
+                    mut cache_read,
+                    mut cache_creation,
+                    mut done,
+                )| async move {
+                    if done {
+                        return None;
+                    }
+
+                    loop {
+                        let item = match es.next().await {
+                            Some(event) => event,
+                            None => {
+                                // Stream ended without message_stop — synthesize Done
+                                let usage =
+                                    make_usage(input_tok, output_tok, cache_read, cache_creation);
+                                done = true;
+                                return Some((
+                                    Ok(LlmEvent::Done { usage }),
+                                    (
+                                        es,
+                                        blocks,
+                                        input_tok,
+                                        output_tok,
+                                        cache_read,
+                                        cache_creation,
+                                        done,
+                                    ),
+                                ));
+                            }
+                        };
+
+                        let msg = match item {
+                            Ok(Event::Open) => continue, // connection opened, no payload
+                            Ok(Event::Message(msg)) => msg,
+                            Err(e) => {
+                                done = true;
+                                return Some((
+                                    Err(anyhow::anyhow!("SSE transport error: {e}")),
+                                    (
+                                        es,
+                                        blocks,
+                                        input_tok,
+                                        output_tok,
+                                        cache_read,
+                                        cache_creation,
+                                        done,
+                                    ),
+                                ));
+                            }
+                        };
+
+                        let event: AnthropicSseEvent = match serde_json::from_str(&msg.data) {
+                            Ok(ev) => ev,
+                            Err(e) => {
+                                // Unknown or malformed event — log and skip
+                                tracing::warn!(
+                                    event_type = %msg.event,
+                                    error = %e,
+                                    "Skipping unparseable SSE event"
+                                );
+                                continue;
+                            }
+                        };
+
+                        match event {
+                            AnthropicSseEvent::MessageStart { message } => {
+                                input_tok = message.usage.input_tokens;
+                                cache_read = message.usage.cache_read_input_tokens;
+                                cache_creation = message.usage.cache_creation_input_tokens;
+                                // continue looping — nothing to emit yet
+                            }
+                            AnthropicSseEvent::ContentBlockStart {
+                                index,
+                                content_block,
+                            } => {
+                                let state = match &content_block.content {
+                                    ContentType::Text { .. } => BlockState::Text,
+                                    ContentType::Thinking { .. } => BlockState::Thinking,
+                                    ContentType::ToolUse { id, name, .. } => BlockState::ToolUse {
+                                        id: id.clone(),
+                                        name: name.clone(),
+                                        json_acc: String::new(),
+                                    },
+                                    ContentType::ToolResult { .. } => BlockState::Text,
+                                };
+                                blocks.insert(index, state);
+                            }
+                            AnthropicSseEvent::ContentBlockDelta { index, delta } => {
+                                match delta {
+                                    AnthropicDelta::Text { text } => {
+                                        return Some((
+                                            Ok(LlmEvent::Text { text }),
+                                            (
+                                                es,
+                                                blocks,
+                                                input_tok,
+                                                output_tok,
+                                                cache_read,
+                                                cache_creation,
+                                                done,
+                                            ),
+                                        ));
+                                    }
+                                    AnthropicDelta::Thinking { thinking } => {
+                                        return Some((
+                                            Ok(LlmEvent::Thinking { thinking }),
+                                            (
+                                                es,
+                                                blocks,
+                                                input_tok,
+                                                output_tok,
+                                                cache_read,
+                                                cache_creation,
+                                                done,
+                                            ),
+                                        ));
+                                    }
+                                    AnthropicDelta::InputJson { partial_json } => {
+                                        let key = index;
+                                        if let Some(BlockState::ToolUse {
+                                            id,
+                                            name,
+                                            ref mut json_acc,
+                                        }) = blocks.get_mut(&key)
+                                        {
+                                            json_acc.push_str(&partial_json);
+                                            return Some((
+                                                Ok(LlmEvent::ToolUseDelta {
+                                                    id: id.clone(),
+                                                    name: Some(name.clone()),
+                                                    input_json: partial_json,
+                                                }),
+                                                (
+                                                    es,
+                                                    blocks,
+                                                    input_tok,
+                                                    output_tok,
+                                                    cache_read,
+                                                    cache_creation,
+                                                    done,
+                                                ),
+                                            ));
+                                        }
+                                        // ToolUseDelta for unknown index — ignore
+                                    }
+                                    AnthropicDelta::Signature { .. } => {
+                                        // Signature deltas accumulate internally;
+                                        // the agent loop doesn't need them.
+                                    }
+                                }
+                            }
+                            AnthropicSseEvent::ContentBlockStop { index } => {
+                                if let Some(BlockState::ToolUse { id, name, json_acc }) =
+                                    blocks.remove(&index)
+                                {
+                                    match serde_json::from_str(&json_acc) {
+                                        Ok(input) => {
+                                            return Some((
+                                                Ok(LlmEvent::ToolUseComplete { id, name, input }),
+                                                (
+                                                    es,
+                                                    blocks,
+                                                    input_tok,
+                                                    output_tok,
+                                                    cache_read,
+                                                    cache_creation,
+                                                    done,
+                                                ),
+                                            ));
+                                        }
+                                        Err(e) => {
+                                            return Some((
+                                                Ok(LlmEvent::Error {
+                                                    error: format!(
+                                                        "Failed to parse tool input JSON: {e}"
+                                                    ),
+                                                }),
+                                                (
+                                                    es,
+                                                    blocks,
+                                                    input_tok,
+                                                    output_tok,
+                                                    cache_read,
+                                                    cache_creation,
+                                                    done,
+                                                ),
+                                            ));
+                                        }
+                                    }
+                                }
+                                blocks.remove(&index);
+                            }
+                            AnthropicSseEvent::MessageDelta {
+                                usage: delta_usage, ..
+                            } => {
+                                // message_delta carries the final output token count
+                                output_tok = delta_usage.output_tokens;
+                            }
+                            AnthropicSseEvent::MessageStop {} => {
+                                let usage =
+                                    make_usage(input_tok, output_tok, cache_read, cache_creation);
+                                done = true;
+                                return Some((
+                                    Ok(LlmEvent::Done { usage }),
+                                    (
+                                        es,
+                                        blocks,
+                                        input_tok,
+                                        output_tok,
+                                        cache_read,
+                                        cache_creation,
+                                        done,
+                                    ),
+                                ));
+                            }
+                            AnthropicSseEvent::Error { error } => {
+                                done = true;
+                                return Some((
+                                    Ok(LlmEvent::Error {
+                                        error: format!("{}: {}", error.error_type, error.message),
+                                    }),
+                                    (
+                                        es,
+                                        blocks,
+                                        input_tok,
+                                        output_tok,
+                                        cache_read,
+                                        cache_creation,
+                                        done,
+                                    ),
+                                ));
+                            }
+                            AnthropicSseEvent::Ping {} => {
+                                // Keep-alive pings — ignore
+                            }
+                        }
+                        // If we reach here, the event didn't produce a stream item;
+                        // continue the inner loop.
+                    }
+                },
+            );
+
+            Ok(Box::pin(llm_stream) as LlmStream)
+        })
+    }
+}
+
+/// Synthesize an [`LlmUsage`] from the fields accumulated across
+/// `message_start` and `message_delta`.
+fn make_usage(
+    input: Option<u32>,
+    output: Option<u32>,
+    cache_read: Option<u32>,
+    cache_create: Option<u32>,
+) -> Option<LlmUsage> {
+    if input.is_none() && output.is_none() {
+        return None;
+    }
+    Some(LlmUsage {
+        input_tokens: input.unwrap_or(0),
+        output_tokens: output.unwrap_or(0),
+        cache_read_tokens: cache_read,
+        cache_creation_tokens: cache_create,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
@@ -145,5 +607,100 @@ mod tests {
             assert_eq!(index, 1);
             assert_eq!(delta, AnthropicDelta::Text { text: "Hello world".into() });
         } other => panic!("expected ContentBlockDelta, got {other:?}"), }
+    }
+
+    // -- extract_system tests --
+
+    #[test]
+    fn test_extract_system_single_text() {
+        let messages = vec![
+            Message::system("You are a helpful assistant."),
+            Message::user("hello"),
+        ];
+        let (system, rest) = extract_system(messages);
+        assert_eq!(rest.len(), 1);
+        assert_eq!(rest[0].role, Role::User);
+        match system {
+            Some(AnthropicSystem::String(s)) => {
+                assert_eq!(s, "You are a helpful assistant.");
+            }
+            other => panic!("expected AnthropicSystem::String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_system_no_system() {
+        let messages = vec![
+            Message::user("hello"),
+            Message::assistant("hi"),
+        ];
+        let (system, rest) = extract_system(messages);
+        assert!(system.is_none());
+        assert_eq!(rest.len(), 2);
+    }
+
+    #[test]
+    fn test_extract_system_multi_block() {
+        let mut system_msg = Message::system("hello");
+        system_msg.content.push(ContentBlock::text("world"));
+        let messages = vec![system_msg, Message::user("q")];
+        let (system, rest) = extract_system(messages);
+        assert_eq!(rest.len(), 1);
+        match system {
+            Some(AnthropicSystem::Blocks(blocks)) => {
+                assert_eq!(blocks.len(), 2);
+            }
+            other => panic!("expected AnthropicSystem::Blocks, got {other:?}"),
+        }
+    }
+
+    // -- make_usage tests --
+
+    #[test]
+    fn test_make_usage_all_fields() {
+        let usage = make_usage(Some(100), Some(50), Some(20), Some(10));
+        let u = usage.unwrap();
+        assert_eq!(u.input_tokens, 100);
+        assert_eq!(u.output_tokens, 50);
+        assert_eq!(u.cache_read_tokens, Some(20));
+        assert_eq!(u.cache_creation_tokens, Some(10));
+    }
+
+    #[test]
+    fn test_make_usage_no_data() {
+        assert!(make_usage(None, None, None, None).is_none());
+    }
+
+    #[test]
+    fn test_make_usage_partial() {
+        let usage = make_usage(Some(50), None, None, None).unwrap();
+        assert_eq!(usage.input_tokens, 50);
+        assert_eq!(usage.output_tokens, 0);
+    }
+
+    // -- AnthropicUsageSummary cache fields --
+
+    #[test]
+    fn test_usage_summary_with_cache_fields() {
+        let json = r#"{
+            "input_tokens": 500,
+            "output_tokens": 0,
+            "cache_read_input_tokens": 300,
+            "cache_creation_input_tokens": 100
+        }"#;
+        let usage: AnthropicUsageSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.input_tokens, Some(500));
+        assert_eq!(usage.output_tokens, Some(0));
+        assert_eq!(usage.cache_read_input_tokens, Some(300));
+        assert_eq!(usage.cache_creation_input_tokens, Some(100));
+    }
+
+    #[test]
+    fn test_usage_summary_without_cache_fields() {
+        let json = r#"{"input_tokens": 100, "output_tokens": 0}"#;
+        let usage: AnthropicUsageSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.input_tokens, Some(100));
+        assert!(usage.cache_read_input_tokens.is_none());
+        assert!(usage.cache_creation_input_tokens.is_none());
     }
 }

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use futures::StreamExt;
+use futures::{stream, StreamExt};
 use reqwest_eventsource::{retry::RetryPolicy, Event, EventSource};
 
 use crate::llm::provider::LlmProvider;
@@ -143,11 +143,28 @@ enum BlockState {
     },
 }
 
+/// Accumulated state for the `stream::unfold` SSE state machine.
+///
+/// A named struct rather than an anonymous tuple so that adding a field
+/// touches only the initialisation site and the one place the field is
+/// updated, not every `return Some(...)` site.
+// EventSource doesn't implement Debug, so we can't derive it here.
+struct StreamState {
+    es: EventSource,
+    blocks: HashMap<u32, BlockState>,
+    input_tok: Option<u32>,
+    output_tok: Option<u32>,
+    cache_read: Option<u32>,
+    cache_creation: Option<u32>,
+    done: bool,
+}
+
 // ---------------------------------------------------------------------------
 // AnthropicProvider
 // ---------------------------------------------------------------------------
 
-static ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 
 /// Anthropic `/v1/messages` SSE client implementing [`LlmProvider`].
 ///
@@ -222,7 +239,7 @@ impl LlmProvider for AnthropicProvider {
             let thinking = if config.thinking {
                 Some(AnthropicThinking {
                     thinking_type: "enabled".to_string(),
-                    budget_tokens: config.thinking_budget.unwrap_or(1024),
+                    budget_tokens: config.thinking_budget.unwrap_or(8192),
                 })
             } else {
                 None
@@ -245,7 +262,7 @@ impl LlmProvider for AnthropicProvider {
             let builder = client
                 .post(format!("{}/v1/messages", ANTHROPIC_BASE_URL))
                 .header("x-api-key", &api_key)
-                .header("anthropic-version", "2023-06-01")
+                .header("anthropic-version", ANTHROPIC_API_VERSION)
                 .json(&request);
 
             // EventSource adds Accept: text/event-stream and handles SSE parsing
@@ -255,56 +272,39 @@ impl LlmProvider for AnthropicProvider {
 
             // State machine: SSE events → LlmEvent stream
             //
-            // We use futures::stream::unfold to drive the EventSource and
-            // map raw SSE events into LlmEvent items.  Intermediate events
-            // (like `content_block_start` that just record metadata, or
-            // `ping`) loop without yielding until a user-visible event is
-            // ready.
-            use futures::stream;
+            // We use stream::unfold to drive the EventSource and map raw SSE
+            // events into LlmEvent items.  Intermediate events (like
+            // `content_block_start` that just record metadata, or `ping`)
+            // loop without yielding until a user-visible event is ready.
 
             let llm_stream = stream::unfold(
-                (
+                StreamState {
                     es,
-                    HashMap::<u32, BlockState>::new(),
-                    None,  // input_tokens
-                    None,  // output_tokens
-                    None,  // cache_read
-                    None,  // cache_creation
-                    false, // done
-                ),
-                move |(
-                    mut es,
-                    mut blocks,
-                    mut input_tok,
-                    mut output_tok,
-                    mut cache_read,
-                    mut cache_creation,
-                    mut done,
-                )| async move {
-                    if done {
+                    blocks: HashMap::new(),
+                    input_tok: None,
+                    output_tok: None,
+                    cache_read: None,
+                    cache_creation: None,
+                    done: false,
+                },
+                move |mut state| async move {
+                    if state.done {
                         return None;
                     }
 
                     loop {
-                        let item = match es.next().await {
+                        let item = match state.es.next().await {
                             Some(event) => event,
                             None => {
                                 // Stream ended without message_stop — synthesize Done
-                                let usage =
-                                    make_usage(input_tok, output_tok, cache_read, cache_creation);
-                                done = true;
-                                return Some((
-                                    Ok(LlmEvent::Done { usage }),
-                                    (
-                                        es,
-                                        blocks,
-                                        input_tok,
-                                        output_tok,
-                                        cache_read,
-                                        cache_creation,
-                                        done,
-                                    ),
-                                ));
+                                let usage = make_usage(
+                                    state.input_tok,
+                                    state.output_tok,
+                                    state.cache_read,
+                                    state.cache_creation,
+                                );
+                                state.done = true;
+                                return Some((Ok(LlmEvent::Done { usage }), state));
                             }
                         };
 
@@ -312,18 +312,10 @@ impl LlmProvider for AnthropicProvider {
                             Ok(Event::Open) => continue, // connection opened, no payload
                             Ok(Event::Message(msg)) => msg,
                             Err(e) => {
-                                done = true;
+                                state.done = true;
                                 return Some((
                                     Err(anyhow::anyhow!("SSE transport error: {e}")),
-                                    (
-                                        es,
-                                        blocks,
-                                        input_tok,
-                                        output_tok,
-                                        cache_read,
-                                        cache_creation,
-                                        done,
-                                    ),
+                                    state,
                                 ));
                             }
                         };
@@ -343,16 +335,16 @@ impl LlmProvider for AnthropicProvider {
 
                         match event {
                             AnthropicSseEvent::MessageStart { message } => {
-                                input_tok = message.usage.input_tokens;
-                                cache_read = message.usage.cache_read_input_tokens;
-                                cache_creation = message.usage.cache_creation_input_tokens;
+                                state.input_tok = message.usage.input_tokens;
+                                state.cache_read = message.usage.cache_read_input_tokens;
+                                state.cache_creation = message.usage.cache_creation_input_tokens;
                                 // continue looping — nothing to emit yet
                             }
                             AnthropicSseEvent::ContentBlockStart {
                                 index,
                                 content_block,
                             } => {
-                                let state = match &content_block.content {
+                                let block = match &content_block.content {
                                     ContentType::Text { .. } => BlockState::Text,
                                     ContentType::Thinking { .. } => BlockState::Thinking,
                                     ContentType::ToolUse { id, name, .. } => BlockState::ToolUse {
@@ -362,62 +354,34 @@ impl LlmProvider for AnthropicProvider {
                                     },
                                     ContentType::ToolResult { .. } => BlockState::Text,
                                 };
-                                blocks.insert(index, state);
+                                state.blocks.insert(index, block);
                             }
                             AnthropicSseEvent::ContentBlockDelta { index, delta } => {
                                 match delta {
                                     AnthropicDelta::Text { text } => {
-                                        return Some((
-                                            Ok(LlmEvent::Text { text }),
-                                            (
-                                                es,
-                                                blocks,
-                                                input_tok,
-                                                output_tok,
-                                                cache_read,
-                                                cache_creation,
-                                                done,
-                                            ),
-                                        ));
+                                        return Some((Ok(LlmEvent::Text { text }), state));
                                     }
                                     AnthropicDelta::Thinking { thinking } => {
-                                        return Some((
-                                            Ok(LlmEvent::Thinking { thinking }),
-                                            (
-                                                es,
-                                                blocks,
-                                                input_tok,
-                                                output_tok,
-                                                cache_read,
-                                                cache_creation,
-                                                done,
-                                            ),
-                                        ));
+                                        return Some((Ok(LlmEvent::Thinking { thinking }), state));
                                     }
                                     AnthropicDelta::InputJson { partial_json } => {
-                                        let key = index;
                                         if let Some(BlockState::ToolUse {
                                             id,
                                             name,
                                             ref mut json_acc,
-                                        }) = blocks.get_mut(&key)
+                                        }) = state.blocks.get_mut(&index)
                                         {
                                             json_acc.push_str(&partial_json);
+                                            let id = id.clone();
+                                            let name = Some(name.clone());
+                                            // NLL: borrow on state.blocks ends here
                                             return Some((
                                                 Ok(LlmEvent::ToolUseDelta {
-                                                    id: id.clone(),
-                                                    name: Some(name.clone()),
+                                                    id,
+                                                    name,
                                                     input_json: partial_json,
                                                 }),
-                                                (
-                                                    es,
-                                                    blocks,
-                                                    input_tok,
-                                                    output_tok,
-                                                    cache_read,
-                                                    cache_creation,
-                                                    done,
-                                                ),
+                                                state,
                                             ));
                                         }
                                         // ToolUseDelta for unknown index — ignore
@@ -430,21 +394,13 @@ impl LlmProvider for AnthropicProvider {
                             }
                             AnthropicSseEvent::ContentBlockStop { index } => {
                                 if let Some(BlockState::ToolUse { id, name, json_acc }) =
-                                    blocks.remove(&index)
+                                    state.blocks.remove(&index)
                                 {
                                     match serde_json::from_str(&json_acc) {
                                         Ok(input) => {
                                             return Some((
                                                 Ok(LlmEvent::ToolUseComplete { id, name, input }),
-                                                (
-                                                    es,
-                                                    blocks,
-                                                    input_tok,
-                                                    output_tok,
-                                                    cache_read,
-                                                    cache_creation,
-                                                    done,
-                                                ),
+                                                state,
                                             ));
                                         }
                                         Err(e) => {
@@ -454,15 +410,7 @@ impl LlmProvider for AnthropicProvider {
                                                         "Failed to parse tool input JSON: {e}"
                                                     ),
                                                 }),
-                                                (
-                                                    es,
-                                                    blocks,
-                                                    input_tok,
-                                                    output_tok,
-                                                    cache_read,
-                                                    cache_creation,
-                                                    done,
-                                                ),
+                                                state,
                                             ));
                                         }
                                     }
@@ -472,40 +420,25 @@ impl LlmProvider for AnthropicProvider {
                                 usage: delta_usage, ..
                             } => {
                                 // message_delta carries the final output token count
-                                output_tok = delta_usage.output_tokens;
+                                state.output_tok = delta_usage.output_tokens;
                             }
                             AnthropicSseEvent::MessageStop {} => {
-                                let usage =
-                                    make_usage(input_tok, output_tok, cache_read, cache_creation);
-                                done = true;
-                                return Some((
-                                    Ok(LlmEvent::Done { usage }),
-                                    (
-                                        es,
-                                        blocks,
-                                        input_tok,
-                                        output_tok,
-                                        cache_read,
-                                        cache_creation,
-                                        done,
-                                    ),
-                                ));
+                                let usage = make_usage(
+                                    state.input_tok,
+                                    state.output_tok,
+                                    state.cache_read,
+                                    state.cache_creation,
+                                );
+                                state.done = true;
+                                return Some((Ok(LlmEvent::Done { usage }), state));
                             }
                             AnthropicSseEvent::Error { error } => {
-                                done = true;
+                                state.done = true;
                                 return Some((
                                     Ok(LlmEvent::Error {
                                         error: format!("{}: {}", error.error_type, error.message),
                                     }),
-                                    (
-                                        es,
-                                        blocks,
-                                        input_tok,
-                                        output_tok,
-                                        cache_read,
-                                        cache_creation,
-                                        done,
-                                    ),
+                                    state,
                                 ));
                             }
                             AnthropicSseEvent::Ping {} => {

--- a/src/llm/anthropic.rs
+++ b/src/llm/anthropic.rs
@@ -45,13 +45,9 @@ pub struct AnthropicRequest {
 }
 #[derive(Debug, Clone, Deserialize)]
 pub struct AnthropicUsageSummary {
-    #[serde(default)]
     pub input_tokens: Option<u32>,
-    #[serde(default)]
     pub output_tokens: Option<u32>,
-    #[serde(default)]
     pub cache_read_input_tokens: Option<u32>,
-    #[serde(default)]
     pub cache_creation_input_tokens: Option<u32>,
 }
 #[derive(Debug, Clone, Deserialize)]
@@ -85,6 +81,7 @@ pub struct AnthropicError {
     pub error_type: String,
     pub message: String,
 }
+// Keep each variant on one line for readability against the Anthropic SSE spec
 #[rustfmt::skip]
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
@@ -232,7 +229,7 @@ impl LlmProvider for AnthropicProvider {
             };
 
             let request = AnthropicRequest {
-                model: model.clone(),
+                model,
                 max_tokens: config.max_tokens,
                 messages,
                 system,
@@ -470,7 +467,6 @@ impl LlmProvider for AnthropicProvider {
                                         }
                                     }
                                 }
-                                blocks.remove(&index);
                             }
                             AnthropicSseEvent::MessageDelta {
                                 usage: delta_usage, ..
@@ -550,6 +546,7 @@ fn make_usage(
 // Tests
 // ---------------------------------------------------------------------------
 
+// Keep test definitions compact and scannable against the SSE spec
 #[rustfmt::skip]
 #[cfg(test)]
 mod tests {
@@ -607,6 +604,63 @@ mod tests {
             assert_eq!(index, 1);
             assert_eq!(delta, AnthropicDelta::Text { text: "Hello world".into() });
         } other => panic!("expected ContentBlockDelta, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_content_block_start_deserialization() {
+        // ContentBlockStart for a thinking block with signature
+        let json = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"Let me think about this","signature":"sig_abc"}}"#;
+        let event: AnthropicSseEvent = serde_json::from_str(json).unwrap();
+        match event { AnthropicSseEvent::ContentBlockStart { index, content_block } => {
+            assert_eq!(index, 0);
+            assert_eq!(content_block.content, ContentType::Thinking { thinking: "Let me think about this".into(), signature: "sig_abc".into() });
+        } other => panic!("expected ContentBlockStart, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_content_block_stop_deserialization() {
+        let event: AnthropicSseEvent = serde_json::from_str(r#"{"type":"content_block_stop","index":2}"#).unwrap();
+        match event { AnthropicSseEvent::ContentBlockStop { index } => {
+            assert_eq!(index, 2);
+        } other => panic!("expected ContentBlockStop, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_message_delta_deserialization() {
+        // message_delta carries usage at the top level alongside delta,
+        // not nested inside delta — this is the trickiest wire format.
+        let json = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42}}"#;
+        let event: AnthropicSseEvent = serde_json::from_str(json).unwrap();
+        match event { AnthropicSseEvent::MessageDelta { delta, usage } => {
+            assert_eq!(delta.stop_reason, Some("end_turn".into()));
+            assert!(delta.stop_sequence.is_none());
+            assert_eq!(usage.output_tokens, Some(42));
+            assert!(usage.input_tokens.is_none());
+        } other => panic!("expected MessageDelta, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_message_stop_deserialization() {
+        let event: AnthropicSseEvent = serde_json::from_str(r#"{"type":"message_stop"}"#).unwrap();
+        match event { AnthropicSseEvent::MessageStop {} => {},
+            other => panic!("expected MessageStop, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_error_sse_event_deserialization() {
+        let json = r#"{"type":"error","error":{"type":"api_error","message":"Internal server error"}}"#;
+        let event: AnthropicSseEvent = serde_json::from_str(json).unwrap();
+        match event { AnthropicSseEvent::Error { error } => {
+            assert_eq!(error.error_type, "api_error");
+            assert_eq!(error.message, "Internal server error");
+        } other => panic!("expected Error, got {other:?}"), }
+    }
+
+    #[test]
+    fn test_ping_sse_event_deserialization() {
+        let event: AnthropicSseEvent = serde_json::from_str(r#"{"type":"ping"}"#).unwrap();
+        match event { AnthropicSseEvent::Ping {} => {},
+            other => panic!("expected Ping, got {other:?}"), }
     }
 
     // -- extract_system tests --

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -387,6 +387,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_content_type_thinking_roundtrip() {
+        let ct = ContentType::Thinking {
+            thinking: "Let me reason about this.".to_string(),
+            signature: "sig_abc123".to_string(),
+        };
+        let json = serde_json::to_value(&ct).unwrap();
+        assert_eq!(json["type"], "thinking");
+        assert_eq!(json["thinking"], "Let me reason about this.");
+        assert_eq!(json["signature"], "sig_abc123");
+
+        // Round-trip: serialize then deserialize
+        let deserialized: ContentType = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized, ct);
+    }
+
+    #[test]
+    fn test_content_type_thinking_no_signature() {
+        // signature has #[serde(default)], so it can be absent
+        let json = r#"{"type":"thinking","thinking":"A quick thought"}"#;
+        let ct: ContentType = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            ct,
+            ContentType::Thinking {
+                thinking: "A quick thought".to_string(),
+                signature: String::new(),
+            }
+        );
+    }
+
     // -- ToolDef tests --
 
     #[test]

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -38,6 +38,17 @@ pub enum ContentType {
         #[serde(default)]
         is_error: bool,
     },
+    /// Anthropic extended thinking content block.
+    ///
+    /// Present when `thinking.enabled` is set in the request. The initial
+    /// `thinking` text arrives via `content_block_start`; subsequent chunks
+    /// arrive as `thinking_delta` events.
+    #[serde(rename = "thinking")]
+    Thinking {
+        thinking: String,
+        #[serde(default)]
+        signature: String,
+    },
 }
 
 /// Cache control annotation for prompt caching (currently only "ephemeral").

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -198,6 +198,11 @@ pub enum LlmEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         usage: Option<LlmUsage>,
     },
+    /// An error at the LLM API/protocol layer (e.g., rate limiting, content
+    /// policy violation). This is distinct from transport-level errors
+    /// (broken connection, DNS failure) which propagate as `Err(...)` on
+    /// the stream item itself. The agent loop may retry transport errors
+    /// but typically treats protocol errors as terminal.
     #[serde(rename = "error")]
     Error { error: String },
 }


### PR DESCRIPTION
## Summary
- Implements `LlmProvider` trait for Anthropic's `/v1/messages` SSE streaming API
- SSE state machine maps raw Anthropic events → unified `LlmEvent` stream
- Tool-use delta accumulation: buffers partial JSON per tool-call ID, emits `ToolUseComplete` on `content_block_stop`
- Extended thinking support: handles thinking blocks and signature deltas
- System prompt extraction from messages to Anthropic's top-level `system` field
- Token usage synthesis from `message_start` (input/cache tokens) + `message_delta` (output tokens)

## Files Changed
- `Cargo.toml` — Added `json` feature to reqwest dependency (+1/-1)
- `src/llm/types.rs` — Added `ContentType::Thinking` variant with serde tests (+41)
- `src/llm/anthropic.rs` — Full SSE streaming implementation + tests (+617/-3)

## Key Design Decisions
- Uses `reqwest_eventsource::EventSource` with custom `NoRetry` policy — agent loop handles retry at higher level
- State machine via `futures::stream::unfold` — passes state by value between iterations
- Tool JSON coalesces `input_json_delta` fragments per `content_block` index, parses on `content_block_stop`
- Usage merges `message_start.usage` (input_tokens, cache) with `message_delta.usage` (output_tokens)

## ⚠️ Line Cap Note
The diff (656 lines) exceeds the DENSE cap of 100 lines. The reviewer noted this is acceptable given the self-contained nature of the SSE state machine. Most of the volume comes from:
1. Many match arms for Anthropic's 9 SSE event types (inherent to the protocol)
2. Comprehensive tests (8 new deserialization tests for all SSE variants)
3. Detailed documentation comments

## DoD Verification
- [x] `cargo build` — passes
- [x] `cargo test` — 107 tests, all green
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt -- --check` — passes
- [x] Rust-reviewer approved (all critical findings addressed)
- [x] SSH-signed commits
- [x] No new dependencies (only feature flag enable on existing dep)
- [x] Public API changes: additive only (`ContentType::Thinking` variant, `AnthropicUsageSummary` cache fields)

Closes #17