### PR TITLE
chore: harden agent review/code patterns from #25/#26 learnings

### DIFF
--- a/.opencode/subagents/rust-coder.md
+++ b/.opencode/subagents/rust-coder.md
@@ -127,6 +127,15 @@ If `cargo clippy` fails, fix warnings. If `cargo test` fails, fix tests or the c
 - `#[serde(untagged)]`: variant order matters. The first variant that deserializes wins. Document the order choice in a comment.
 - Tagged enums (`#[serde(tag = "type")]`): every variant gets at least one deserialization test.
 
+### Tool Implementation Patterns
+
+- **Sandboxed commands**: Always `env_clear()` + minimal `PATH`/`HOME`. Child processes inherit parent env by default — API keys leak.
+- **Multi-file read tools**: Output must include file path/identifier per line. The LLM needs to know which file each result came from.
+- **Caps and limits**: Check at ALL granularity levels. File-level cap AND per-line cap. A single file with more matches than `max_results` must still be capped.
+- **Task lifecycle**: `tokio::spawn()` handles must be awaited or aborted on EVERY code path, including error and timeout branches. Orphaned tasks leak allocations.
+- **Platform gates**: Tests using `echo`, `sleep`, `dd`, `/dev/zero` must be `#[cfg(unix)]`.
+- **Error silence**: Every `Err(_) => continue` or `Err(_) => {}` arm must include `tracing::debug!` or `tracing::warn!`.
+
 ### Test Coverage Standards
 
 - **Tagged enums**: at least one deserialization test per variant.
@@ -157,4 +166,8 @@ If `cargo clippy` fails, fix warnings. If `cargo test` fails, fix tests or the c
 - Don't hardcode secrets, API keys, or credentials
 - Don't skip input validation on CLI args or parsed data
 - Don't use `unwrap()` or `expect()` in production code paths
+- Don't spawn child processes without `env_clear()` — API keys and secrets leak through inherited environment
+- Don't leave spawned `tokio::task` handles unawaited/ unaborted on error paths — orphaned tasks leak allocations
+- Don't produce multi-file search/read output without a file identifier per result line
+- Don't use `assert!(x <= N)` where N=0 means "the feature under test doesn't work at all" — use `assert_eq!`
 - Don't ignore parse failures in tree-sitter operations

--- a/.opencode/subagents/rust-reviewer.md
+++ b/.opencode/subagents/rust-reviewer.md
@@ -86,6 +86,21 @@ This subagent is invoked by `rust-expert` for:
 - [ ] **No untested public items**: Cross-reference `pub` types/functions against the test module. Every `pub fn`, `pub struct`, and `pub enum` variant must appear in at least one test. Flag any with zero coverage.
 - [ ] **The trickiest wire feature**: Identify the most unusual field in the API format and test it specifically (e.g., Anthropic's top-level `usage` in `message_delta`, not nested inside `delta`).
 - [ ] **Edge cases**: Empty arrays, null fields, missing required fields, unknown variants.
+- [ ] **Assertions are precise, not vacuous**: `== N` not `<= N` where N=0 means "feature doesn't work at all". Flag `<=` and `>=` assertions where the boundary value allows the test to pass even if nothing happens.
+- [ ] **Platform gates**: Tests invoking external commands (`echo`, `sleep`, `dd`, Unix paths) must have `#[cfg(unix)]` or equivalent.
+
+### 9. Tool Output Contracts
+
+- [ ] **Multi-file tools include file identifier in every result line**: Path/filename must be present so LLM knows where matches came from. `search_files` must prefix with relative path.
+- [ ] **Caps/thresholds checked at ALL relevant granularity levels**: File-level AND per-line-level guards where data can straddle boundaries. A single-file overflow must be caught.
+- [ ] **`Command::new()` / `Command::spawn()` with explicit env control**: `env_clear()` or curated env; no accidental API key / secret inheritance from parent process.
+- [ ] **Task lifecycle on error paths**: `tokio::spawn()` handles must be explicitly aborted or awaited on ALL code paths — no orphaned tasks leaking allocations.
+
+### 10. Documentation & Terminology
+
+- [ ] **Terms match implementation**: No doc strings, comments, or `description()` that promise more than the code delivers. "sandboxed" means filesystem isolation — "resource-limited" is honest about timeout+cwd+cap.
+- [ ] **All error-silence paths logged**: Every `Err(_) => continue` or `Err(_) => {}` must include `tracing::debug!` or `tracing::warn!` — silent error suppression hides bugs.
+- [ ] **Truncation/cap comments are accurate**: If `OUTPUT_CAP` docs say "raw bytes" but applies to formatted output, fix the comment.
 
 ## Review Output Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,23 @@ The reviewer (rust-reviewer) must go beyond mechanical DoD checks. These apply t
 - Cross-reference request/response fields against the provider's API reference.
 - Test the trickiest wire format feature (e.g., Anthropic's top-level `usage` in `message_delta`, not nested inside `delta`).
 
+### For tool PRs (read_file, search_files, execute_command, edit_file, etc.)
+- **No panics in agent path**: Flag every `.unwrap()`, `.expect()`, `.panic!()`, bare `[i]` without bounds check.
+- **Multi-file output contract**: Every result line from cross-file tools must include a file identifier (relative path).
+- **Caps at all granularities**: File-level AND per-line cap checks where data can straddle boundaries.
+- **Silent errors logged**: Every `Err(_) => continue` must have `tracing::debug!` or `tracing::warn!`.
+- **Test assertion precision**: `assert_eq!(x, N)` not `assert!(x <= N)` where 0 means "feature doesn't work."
+- **Platform-gated tests**: `#[cfg(unix)]` on tests using `echo`, `sleep`, `dd`, `/dev/zero`.
+- **Terminology honesty**: Tool docs must not promise more than implementation delivers (e.g., "sandboxed" → "resource-limited").
+
+### For security-sensitive PRs (command execution, process spawn, network)
+- **Environment isolation**: `Command::new()` must have `env_clear()` or curated env — no API key inheritance.
+- **Task lifecycle**: `tokio::spawn()` handles must be awaited or aborted on ALL code paths, including error/timeout.
+- **Timeout/kill/reap**: Timeout must `start_kill()` + `wait().await` — no zombie processes.
+- **No shell injection**: Commands via `Command::new(cmd).args(args)` — never `sh -c` with string interpolation.
+
+### High-signal pre-scan (run before full review)
+
 ## Dependencies to Know
 
 - `tokio` — multi-threaded runtime, process spawning, channels


### PR DESCRIPTION
## Summary
Incorporates 9 high-signal review patterns discovered across 6 review rounds on `search_files` (#25) and `execute_command` (#26). Updates the rust-reviewer and rust-coder subagent configs so future PRs catch these before the external reviewer sees them.

## Changes

| File | Lines | What |
|------|-------|------|
| `.opencode/subagents/rust-reviewer.md` | +15 | Sections 9-10: tool output contracts, documentation integrity, silent-error logging |
| `.opencode/subagents/rust-coder.md` | +13 | Anti-patterns: env_clear, task lifecycle, multi-file output, platform gates, precise assertions |
| `AGENTS.md` | +17 | Expanded Review Depth Standards: tool-PR checks, security-PR checks, high-signal pre-scan |

## Patterns encoded

| # | Pattern | Layer |
|---|---------|-------|
| 1 | No `.unwrap()` / `.expect()` in agent paths | Reviewer + Coder |
| 2 | Multi-file tools include file path per result line | Reviewer + Coder |
| 3 | `assert_eq!` not vacuous `assert!(<=)` | Reviewer + Coder |
| 4 | Every `Err(_) => continue` has `tracing::debug!` | Reviewer + Coder |
| 5 | `Command::new()` with `env_clear()` — no API key leak | Reviewer + Coder |
| 6 | Caps at all granularities (file-level + per-line) | Reviewer + Coder |
| 7 | Terminology matches implementation | Reviewer |
| 8 | `#[cfg(unix)]` on platform-specific tests | Reviewer + Coder |
| 9 | `tokio::spawn()` handles aborted on error paths | Reviewer + Coder |

## Checks
- Pure docs/config change — no Rust code, nothing to compile
- Diff: 45 lines across 3 files

Closes #25
Closes #26