### PR TITLE
chore: add pre-commit hooks with cargo-husky + git-secrets (#47)

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Pre-commit hook managed by cargo-husky (user-hooks feature).
+# This script runs all checks since user-hooks disables the built-in features.
+
+set -e
+
+# --- Cargo checks ---
+
+echo "Running cargo fmt -- --check..."
+cargo fmt -- --check
+
+echo "Running cargo clippy -- -D warnings..."
+cargo clippy -- -D warnings
+
+echo "Running cargo test..."
+cargo test
+
+# --- Secret scanning (optional) ---
+
+if command -v git-secrets >/dev/null 2>&1; then
+    echo "Running git secrets --scan --staged..."
+
+    # Register allowed patterns for carv project (idempotent).
+    # These are configured per-repo by git-secrets and safe to run on every commit.
+    git secrets --add --literal 'ANTHROPIC_API_KEY' 2>/dev/null || true
+    git secrets --add --literal 'OPENAI_API_KEY' 2>/dev/null || true
+    git secrets --add --literal 'GITHUB_TOKEN' 2>/dev/null || true
+    git secrets --add --literal 'AWS_ACCESS_KEY_ID' 2>/dev/null || true
+    git secrets --add --literal 'AWS_SECRET_ACCESS_KEY' 2>/dev/null || true
+
+    # Scan staged files for secrets.
+    # Redirect stderr to stdout so any warnings are visible.
+    git secrets --scan --staged
+else
+    echo "git-secrets not found. Skipping secret scan."
+    echo "Install from: https://github.com/awslabs/git-secrets"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,60 @@ cargo clippy -- -D warnings
 cargo fmt -- --check
 ```
 
+## Pre-commit Hooks
+
+Client-side git hooks are managed by [cargo-husky](https://github.com/rhysd/cargo-husky). They are auto-installed into `.git/hooks/` on `cargo test`. Hooks run on `git commit`:
+
+| Hook | What it does |
+|---|---|
+| `cargo fmt -- --check` | Rejects unformatted Rust code |
+| `cargo clippy -- -D warnings` | Rejects clippy warnings |
+| `cargo test` | Rejects if any test fails |
+| `git secrets --scan --staged` | Scans staged files for API keys and credentials |
+
+### How it works
+
+cargo-husky uses a `build.rs` that runs during `cargo test` (dev-dependencies are compiled
+for testing). It copies the hook scripts from `.cargo-husky/hooks/` into `.git/hooks/`.
+Since the project uses the `user-hooks` feature, the script at `.cargo-husky/hooks/pre-commit`
+handles all checks — including cargo fmt, clippy, test, and secret scanning.
+
+### Manual installation (worktrees)
+
+cargo-husky v1.5.0 does not fully support git worktrees (the build script cannot parse
+the `gitdir:` prefix in `.git` files). If you work in a worktree, install the hook manually:
+
+```bash
+# Determine the worktree's git hooks directory
+WORKTREE_GITDIR=$(cat .git | sed 's/gitdir: //')/hooks
+mkdir -p "$WORKTREE_GITDIR"
+cp .cargo-husky/hooks/pre-commit "$WORKTREE_GITDIR/pre-commit"
+chmod +x "$WORKTREE_GITDIR/pre-commit"
+```
+
+### Secret scanning
+
+Install [git-secrets](https://github.com/awslabs/git-secrets) for secret detection:
+
+```bash
+# macOS
+brew install git-secrets
+
+# Linux (from source)
+git clone https://github.com/awslabs/git-secrets.git
+cd git-secrets && sudo make install
+```
+
+If git-secrets is not installed, the pre-commit hook skips secret scanning (non-blocking).
+
+### Bypassing hooks
+
+In emergencies, skip hooks with:
+
+```bash
+git commit --no-verify -m "message"
+```
+
 **`Cargo.lock` policy:** Commit it. carv is a binary crate — lockfiles ensure reproducible builds. Library crates omit them; binaries do not.
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,10 +109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "carv"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo-husky",
  "clap",
  "futures",
  "grep-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,10 @@ grep-searcher = "0.1"
 # tree-sitter-python = "0.24"
 # tree-sitter-typescript = "0.24"
 
+[dev-dependencies]
+# Pre-commit hooks (user-hooks feature is mutually exclusive with other features,
+# so the .cargo-husky/hooks/pre-commit script handles all checks).
+cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "user-hooks"] }
+
 [build-dependencies]
 # cc = "1"  # Deferred with tree-sitter; only needed for C grammar compilation.


### PR DESCRIPTION
## Summary

Add client-side pre-commit hooks using cargo-husky (Rust native git hook manager) with the user-hooks feature, which delegates all checks to a custom script. Also integrates git-secrets for scanning staged files for API keys and credentials.

## Changes

- **Cargo.toml**: Add cargo-husky as dev-dependency with `precommit-hook` + `user-hooks` features
- **`.cargo-husky/hooks/pre-commit`**: Custom pre-commit hook script that runs:
  - `cargo fmt -- --check`
  - `cargo clippy -- -D warnings`
  - `cargo test`
  - `git secrets --scan --staged` (if git-secrets is installed)
- **AGENTS.md**: Document pre-commit hooks, manual worktree installation, secret scanning setup

## Design Decisions

- Uses `user-hooks` feature only (mutually exclusive with built-in features) — the script handles everything
- git-secrets is optional (non-blocking if not installed)
- Manual installation steps documented for git worktrees (cargo-husky v1.5.0 has limited worktree support)

## Verification

- [x] cargo build passes
- [x] cargo test (183 tests green)
- [x] cargo clippy -- -D warnings passes
- [x] cargo fmt -- --check passes
- [x] Diff: 103 lines (under 150 cap)
- [x] SSH-signed commit