### PR TITLE
config: add rust-analyzer as Rust LSP server

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [],
+  "lsp": {
+    "rust": {
+      "command": ["rust-analyzer"],
+      "extensions": ["rs"]
+    }
+  },
   "agent": {
     "rust-expert": { "model": "opencode-go/deepseek-v4-pro" },
     "rust-coder": { "model": "opencode-go/deepseek-v4-flash" },


### PR DESCRIPTION
## Summary

Add rust-analyzer as the LSP server for Rust files in opencode configuration.

## Changes

- `.opencode/opencode.json`: Add `lsp.rust` block with `command: [rust-analyzer]` and `extensions: [rs]`

## Verification

- rust-analyzer 1.86.0 is installed and available in PATH
- Configuration follows the [opencode config schema](https://opencode.ai/config.json) for LSP servers

## DoD Checklist

- [x] `cargo build` passes — no Rust code changes
- [x] `cargo test` passes — all 199 tests green
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] No new dependencies added
- [x] No API signature changes
- [x] No security boundary modified
- [x] No design doc impact
- [x] Diff: +6 lines (JSON config only)