### PR TITLE
fix(config): enable LSP diagnostics for all agents + fix kimi-k2.6 subagents

### DIFF
--- a/.opencode/config/agent-metadata.json
+++ b/.opencode/config/agent-metadata.json
@@ -7,8 +7,18 @@
       "path": ".opencode/agents/rust-expert.md",
       "description": "Rust expert agent for systems programming, async Rust, and tooling (tree-sitter, LSP)",
       "triggers": {
-        "file_patterns": ["*.rs", "Cargo.toml"],
-        "keywords": ["rust", "cargo", "tokio", "tree-sitter", "lsp", "async"]
+        "file_patterns": [
+          "*.rs",
+          "Cargo.toml"
+        ],
+        "keywords": [
+          "rust",
+          "cargo",
+          "tokio",
+          "tree-sitter",
+          "lsp",
+          "async"
+        ]
       }
     }
   },
@@ -34,12 +44,10 @@
       "description": "Rust codebase exploration and context discovery"
     },
     "rust-architect": {
-      "type": "general",
       "path": ".opencode/subagents/rust-architect.md",
       "description": "Rust architecture specialist for high-level design decisions"
     },
     "rust-reviewer2": {
-      "type": "general",
       "path": ".opencode/subagents/rust-reviewer2.md",
       "description": "Second-opinion Rust reviewer focusing on architectural coherence, spec compliance, invariants, and cross-module consistency. Complements the checklist-based rust-reviewer."
     }

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -3,17 +3,56 @@
   "plugin": [],
   "lsp": {
     "rust": {
-      "command": ["rust-analyzer"],
-      "extensions": ["rs"]
+      "command": [
+        "rust-analyzer"
+      ],
+      "extensions": [
+        "rs"
+      ]
     }
   },
   "agent": {
-    "rust-expert": { "model": "deepseek/deepseek-v4-pro" },
-    "rust-coder": { "model": "deepseek/deepseek-v4-flash" },
-    "rust-reviewer": { "model": "opencode-go/qwen3.6-plus" },
-    "rust-tester": { "model": "deepseek/deepseek-v4-flash" },
-    "rust-scout": { "model": "deepseek/deepseek-v4-flash" },
-    "rust-architect": { "model": "opencode-go/kimi-k2.6" },
-    "rust-reviewer2": { "model": "opencode-go/kimi-k2.6" }
+    "rust-expert": {
+      "model": "deepseek/deepseek-v4-pro",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-coder": {
+      "model": "deepseek/deepseek-v4-flash",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-reviewer": {
+      "model": "opencode-go/qwen3.6-plus",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-tester": {
+      "model": "deepseek/deepseek-v4-flash",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-scout": {
+      "model": "deepseek/deepseek-v4-flash",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-architect": {
+      "model": "opencode-go/kimi-k2.6",
+      "permission": {
+        "lsp": "allow"
+      }
+    },
+    "rust-reviewer2": {
+      "model": "opencode-go/kimi-k2.6",
+      "permission": {
+        "lsp": "allow"
+      }
+    }
   }
 }

--- a/.opencode/subagents/rust-architect.md
+++ b/.opencode/subagents/rust-architect.md
@@ -2,7 +2,6 @@
 name: rust-architect
 description: "Rust architecture specialist for high-level design decisions. Used sparingly for module boundaries, trait design, and API contracts."
 mode: subagent
-type: general
 tools:
   read: true
   glob: true

--- a/.opencode/subagents/rust-reviewer2.md
+++ b/.opencode/subagents/rust-reviewer2.md
@@ -2,7 +2,6 @@
 name: rust-reviewer2
 description: "Second-opinion Rust reviewer focusing on architectural coherence, spec compliance, invariants, and cross-module consistency. Complements the checklist-based reviewer."
 mode: subagent
-type: general
 tools:
   read: true
   glob: true


### PR DESCRIPTION
## Summary
Two agent configuration fixes:

### 1. Enable LSP diagnostics for all Rust agents
Adding `permission: { lsp: "allow" }` to all 7 Rust agents in `opencode.json`. According to [opencode LSP docs](https://opencode.ai/docs/lsp/), the LSP integration surfaces diagnostics (errors/warnings from rust-analyzer) to the LLM when it reads/edits files. This gives agents immediate feedback on type errors, unused imports, etc. without running `cargo build`.

### 2. Fix kimi-k2.6 subagent type field rejection
`rust-reviewer2` and `rust-architect` (both on `kimi-k2.6`) were failing silently. Root cause: the `type: general` field from agent-metadata.json and YAML frontmatter is forwarded to the model API, and kimi-k2.6 rejects it (`"Extra inputs are not permitted, field: 'type'"`). `qwen3.6-plus` silently accepts it.

Removed `type` from both:
- `.opencode/subagents/rust-reviewer2.md` (YAML frontmatter)
- `.opencode/subagents/rust-architect.md` (YAML frontmatter)
- `.opencode/config/agent-metadata.json` (both entries)

### Requires
- **Session restart** for config changes to take effect

### Verification
- [x] JSON valid (all files parse)
- [x] YAML frontmatter clean (no stray type fields)
- [x] All 7 agents have `lsp: allow` permission