### PR TITLE
feat(treesitter): parser cache with invalidation hooks (#31)

### DIFF
--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -4,6 +4,8 @@
 //! via `tree_sitter_language::LanguageFn` constants. The module maps file
 //! extensions to [`Language`] variants and loads the corresponding grammar.
 
+pub mod parser;
+
 use std::path::Path;
 
 // ---------------------------------------------------------------------------

--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -4,7 +4,7 @@
 //! via `tree_sitter_language::LanguageFn` constants. The module maps file
 //! extensions to [`Language`] variants and loads the corresponding grammar.
 
-pub mod parser;
+pub(crate) mod parser;
 
 use std::path::Path;
 

--- a/src/treesitter/parser.rs
+++ b/src/treesitter/parser.rs
@@ -1,0 +1,204 @@
+//! Tree-sitter parser cache with invalidation hooks.
+//!
+//! [`ParserCache`] manages per-file [`tree_sitter::Tree`] instances, avoiding
+//! redundant parses. The cache is invalidated when tools modify files (via
+//! `AnchorState::notify_edit` or direct calls to [`ParserCache::invalidate`]).
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::{language_for_path, language_grammar};
+
+// ---------------------------------------------------------------------------
+// ParserCache
+// ---------------------------------------------------------------------------
+
+/// Per-file cache of parsed tree-sitter ASTs.
+///
+/// On first access, the file is read from disk, parsed via the appropriate
+/// language grammar, and the resulting [`tree_sitter::Tree`] is stored.
+/// Subsequent accesses return a clone of the cached tree.
+///
+/// When a tool modifies a file, call [`invalidate`](ParserCache::invalidate)
+/// to remove the stale entry — the next access will re-read and re-parse.
+#[derive(Debug, Default)]
+pub struct ParserCache {
+    /// Map from canonical file path → parsed tree.
+    cache: HashMap<PathBuf, tree_sitter::Tree>,
+}
+
+impl ParserCache {
+    /// Create an empty parser cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the parsed tree for `path`, re-parsing if not cached.
+    ///
+    /// The file extension determines which grammar to use. Unsupported
+    /// extensions return an [`io::Error`] with kind [`InvalidInput`].
+    ///
+    /// Returns a clone of the cached [`tree_sitter::Tree`] — the clone is
+    /// cheap (pointer copy). The returned `Tree` is owned and can be used
+    /// independently of the cache.
+    ///
+    /// # Errors
+    ///
+    /// * `io::ErrorKind::InvalidInput` — unsupported file extension.
+    /// * `io::ErrorKind::NotFound` or other I/O errors from reading the file.
+    /// * Parse failures return `io::ErrorKind::InvalidData`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the grammar `set_language` call fails after a valid
+    /// `language_for_path` lookup (should be unreachable).
+    pub fn parse_file(&mut self, path: &Path) -> io::Result<tree_sitter::Tree> {
+        if !self.cache.contains_key(path) {
+            let tree = self.do_parse(path)?;
+            self.cache.insert(path.to_path_buf(), tree);
+        }
+        // Tree::clone is a shallow copy (pointer clone to C-heap data).
+        Ok(self.cache[path].clone())
+    }
+
+    /// Invalidate the cached tree for `path`.
+    ///
+    /// The next call to [`parse_file`] will re-read and re-parse.
+    pub fn invalidate(&mut self, path: &Path) {
+        self.cache.remove(path);
+    }
+
+    /// Return the number of files with cached parse trees.
+    #[allow(dead_code)] // Only called from tests.
+    pub(crate) fn cache_size(&self) -> usize {
+        self.cache.len()
+    }
+
+    // -- internal helpers ----------------------------------------------------
+
+    /// Read, determine language, and parse a file.
+    fn do_parse(&self, path: &Path) -> io::Result<tree_sitter::Tree> {
+        let path_str = path
+            .to_str()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "non-UTF-8 path"))?;
+
+        let lang = language_for_path(path_str).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported file extension for '{}'", path_str),
+            )
+        })?;
+
+        let content = std::fs::read_to_string(path)?;
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&language_grammar(lang))
+            .expect("grammar load failed for valid language");
+
+        parser
+            .parse(&content, None)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "parse returned None"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write content to a temp file and return its path.
+    fn temp_file(name: &str, content: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("carv-test-parser");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        path
+    }
+
+    #[test]
+    fn parse_rust_file() {
+        let path = temp_file("valid.rs", "fn main() {}\n");
+        let mut cache = ParserCache::new();
+
+        let tree = cache.parse_file(&path).unwrap();
+        assert!(
+            !tree.root_node().has_error(),
+            "valid Rust should parse clean"
+        );
+    }
+
+    #[test]
+    fn parse_python_file() {
+        let path = temp_file("valid.py", "def f():\n    pass\n");
+        let mut cache = ParserCache::new();
+
+        let tree = cache.parse_file(&path).unwrap();
+        assert!(
+            !tree.root_node().has_error(),
+            "valid Python should parse clean"
+        );
+    }
+
+    #[test]
+    fn cache_hit_returns_same_tree() {
+        let path = temp_file("cache_hit.rs", "fn main() {}\n");
+        let mut cache = ParserCache::new();
+
+        let tree1 = cache.parse_file(&path).unwrap();
+        let tree2 = cache.parse_file(&path).unwrap();
+
+        assert_eq!(tree1.root_node().to_sexp(), tree2.root_node().to_sexp());
+        assert_eq!(cache.cache_size(), 1, "should only have one cached entry");
+    }
+
+    #[test]
+    fn invalidate_triggers_reparse() {
+        let path = temp_file("reparse.rs", "fn a() {}\n");
+        let mut cache = ParserCache::new();
+
+        let tree1 = cache.parse_file(&path).unwrap();
+        assert!(!tree1.root_node().has_error());
+        assert_eq!(cache.cache_size(), 1);
+
+        // Modify the file on disk and invalidate.
+        std::fs::write(&path, "fn b() {}\n").unwrap();
+        assert_eq!(cache.cache_size(), 1, "cache still holds old tree");
+        cache.invalidate(&path);
+        assert_eq!(cache.cache_size(), 0, "cache cleared after invalidate");
+
+        let tree2 = cache.parse_file(&path).unwrap();
+        assert!(!tree2.root_node().has_error());
+        assert_eq!(cache.cache_size(), 1, "re-parsed and cached");
+    }
+
+    #[test]
+    fn cache_size_tracks_entries() {
+        let a = temp_file("a.rs", "fn a() {}\n");
+        let b = temp_file("b.py", "def b():\n    pass\n");
+        let mut cache = ParserCache::new();
+
+        assert_eq!(cache.cache_size(), 0);
+        let _ = cache.parse_file(&a).unwrap();
+        assert_eq!(cache.cache_size(), 1);
+        let _ = cache.parse_file(&b).unwrap();
+        assert_eq!(cache.cache_size(), 2);
+        cache.invalidate(&a);
+        assert_eq!(cache.cache_size(), 1);
+    }
+
+    #[test]
+    fn file_not_found() {
+        let path = PathBuf::from("/nonexistent/file.rs");
+        let mut cache = ParserCache::new();
+        let err = cache.parse_file(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/src/treesitter/parser.rs
+++ b/src/treesitter/parser.rs
@@ -1,8 +1,8 @@
 //! Tree-sitter parser cache with invalidation hooks.
 //!
 //! [`ParserCache`] manages per-file [`tree_sitter::Tree`] instances, avoiding
-//! redundant parses. The cache is invalidated when tools modify files (via
-//! `AnchorState::notify_edit` or direct calls to [`ParserCache::invalidate`]).
+//! redundant parses. The cache is invalidated by calling [`ParserCache::invalidate`]
+//! — typically after a tool modifies a file.
 
 use std::collections::HashMap;
 use std::io;
@@ -16,28 +16,49 @@ use super::{language_for_path, language_grammar};
 
 /// Per-file cache of parsed tree-sitter ASTs.
 ///
-/// On first access, the file is read from disk, parsed via the appropriate
-/// language grammar, and the resulting [`tree_sitter::Tree`] is stored.
-/// Subsequent accesses return a clone of the cached tree.
+/// On first access, the file is read from disk (as raw bytes — tree-sitter
+/// accepts `&[u8]`, not just UTF-8), parsed via the appropriate language
+/// grammar, and the resulting [`tree_sitter::Tree`] is stored.  Subsequent
+/// accesses return a clone of the cached tree.
 ///
-/// When a tool modifies a file, call [`invalidate`](ParserCache::invalidate)
-/// to remove the stale entry — the next access will re-read and re-parse.
-#[derive(Debug, Default)]
+/// The parser is reused across invocations — a single [`tree_sitter::Parser`]
+/// lives in the cache and is switched to the correct grammar on each parse.
+///
+/// Call [`invalidate`](ParserCache::invalidate) after a tool modifies a file
+/// to force a re-parse on the next access.
 pub struct ParserCache {
     /// Map from canonical file path → parsed tree.
     cache: HashMap<PathBuf, tree_sitter::Tree>,
+    /// Reusable parser — language is switched on each parse.
+    parser: tree_sitter::Parser,
 }
 
+impl std::fmt::Debug for ParserCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParserCache")
+            .field("cached_files", &self.cache.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(dead_code)] // Methods used only from tests; external callers in G5-G6.
 impl ParserCache {
-    /// Create an empty parser cache.
+    /// Create an empty parser cache with a fresh [`tree_sitter::Parser`].
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            cache: HashMap::new(),
+            parser: tree_sitter::Parser::new(),
+        }
     }
 
     /// Return the parsed tree for `path`, re-parsing if not cached.
     ///
-    /// The file extension determines which grammar to use. Unsupported
-    /// extensions return an [`io::Error`] with kind [`InvalidInput`].
+    /// The file extension determines which grammar to use.  The path is
+    /// canonicalized before cache lookup so that equivalent paths (e.g.
+    /// `./foo.rs` and `/abs/foo.rs`) share cache entries.
+    ///
+    /// The file is read as raw bytes (`fs::read`) — tree-sitter accepts
+    /// `&[u8]` directly, so non-UTF-8 files parse correctly.
     ///
     /// Returns a clone of the cached [`tree_sitter::Tree`] — the clone is
     /// cheap (pointer copy). The returned `Tree` is owned and can be used
@@ -54,23 +75,28 @@ impl ParserCache {
     /// Panics if the grammar `set_language` call fails after a valid
     /// `language_for_path` lookup (should be unreachable).
     pub fn parse_file(&mut self, path: &Path) -> io::Result<tree_sitter::Tree> {
-        if !self.cache.contains_key(path) {
-            let tree = self.do_parse(path)?;
-            self.cache.insert(path.to_path_buf(), tree);
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+        // Parse first (borrows self.parser), then insert into cache — avoids
+        // holding a self.cache borrow across the self.parser mutation.
+        // tree_sitter::Parser does not impl Debug, so we manually impl it above.
+        let needs_parse = !self.cache.contains_key(&canonical);
+        if needs_parse {
+            let tree = self.do_parse(path, &canonical)?;
+            self.cache.insert(canonical.clone(), tree);
         }
-        // Tree::clone is a shallow copy (pointer clone to C-heap data).
-        Ok(self.cache[path].clone())
+        Ok(self.cache[&canonical].clone())
     }
 
     /// Invalidate the cached tree for `path`.
     ///
     /// The next call to [`parse_file`] will re-read and re-parse.
     pub fn invalidate(&mut self, path: &Path) {
-        self.cache.remove(path);
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        self.cache.remove(&canonical);
     }
 
     /// Return the number of files with cached parse trees.
-    #[allow(dead_code)] // Only called from tests.
     pub(crate) fn cache_size(&self) -> usize {
         self.cache.len()
     }
@@ -78,8 +104,8 @@ impl ParserCache {
     // -- internal helpers ----------------------------------------------------
 
     /// Read, determine language, and parse a file.
-    fn do_parse(&self, path: &Path) -> io::Result<tree_sitter::Tree> {
-        let path_str = path
+    fn do_parse(&mut self, path: &Path, canonical: &Path) -> io::Result<tree_sitter::Tree> {
+        let path_str = canonical
             .to_str()
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "non-UTF-8 path"))?;
 
@@ -90,14 +116,13 @@ impl ParserCache {
             )
         })?;
 
-        let content = std::fs::read_to_string(path)?;
+        let content = std::fs::read(path)?;
 
-        let mut parser = tree_sitter::Parser::new();
-        parser
+        self.parser
             .set_language(&language_grammar(lang))
             .expect("grammar load failed for valid language");
 
-        parser
+        self.parser
             .parse(&content, None)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "parse returned None"))
     }
@@ -177,6 +202,16 @@ mod tests {
         let tree2 = cache.parse_file(&path).unwrap();
         assert!(!tree2.root_node().has_error());
         assert_eq!(cache.cache_size(), 1, "re-parsed and cached");
+    }
+
+    #[test]
+    fn unsupported_extension_errors() {
+        let path = temp_file("readme.md", "# Hello\n");
+        let mut cache = ParserCache::new();
+
+        let err = cache.parse_file(&path).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(err.to_string().contains("unsupported file extension"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
G2: Tree-sitter parser cache. Parse files into ASTs and cache results, with invalidation on file modifications.

## Implementation
- **ParserCache**: `HashMap\u003cPathBuf, tree_sitter::Tree\u003e` keyed by canonical path
- **parse_file(path)** → determines language from extension, reads file, parses, caches, returns cloned `Tree`
- **invalidate(path)** → removes cached tree (next parse_file re-reads and re-parses)
- **cache_size()** → count of cached entries (test introspection)
- Tree::clone() is cheap — pointer copy to C-heap data (Tree is Clone in tree-sitter 0.26.x)

## 6 unit tests
- Parse valid .rs file → no errors
- Parse valid .py file → no errors
- Cache hit returns identical tree structure
- Invalidate + reparse triggers fresh parse
- Unsupported extension → InvalidInput error
- File not found → NotFound error
- Cache size tracks add/invalidate

## Verification
- [x] cargo build ✅
- [x] cargo test (243/243) ✅
- [x] cargo clippy ✅
- [x] cargo fmt ✅

Closes #31