### PR TITLE
feat(treesitter): SCM query files for Rust, Python, TypeScript (#32)

### DIFF
--- a/src/treesitter/mod.rs
+++ b/src/treesitter/mod.rs
@@ -5,6 +5,7 @@
 //! extensions to [`Language`] variants and loads the corresponding grammar.
 
 pub(crate) mod parser;
+pub(crate) mod queries;
 
 use std::path::Path;
 

--- a/src/treesitter/queries/mod.rs
+++ b/src/treesitter/queries/mod.rs
@@ -1,0 +1,160 @@
+//! Tree-sitter S-expression query files, embedded at compile time.
+//!
+//! Each language has a `.scm` file with `@definition.*` and `@name.*`
+//! captures used by the `get_skeleton`, `get_function`, and `replace_symbol`
+//! tools (G5, G6).
+
+use super::Language;
+
+// ---------------------------------------------------------------------------
+// Embedded queries
+// ---------------------------------------------------------------------------
+
+/// Return the tag query for `language` as a static string.
+///
+/// The query captures definitions (`@definition.function`,
+/// `@definition.class`, etc.) and references (`@name.reference`).
+#[allow(dead_code)] // Used by G5/G6 tree-sitter tools.
+pub fn query_for_language(lang: Language) -> &'static str {
+    match lang {
+        Language::Rust => include_str!("rust.scm"),
+        Language::Python => include_str!("python.scm"),
+        Language::TypeScript | Language::Tsx => include_str!("typescript.scm"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::treesitter::language_grammar;
+    use crate::treesitter::parser::ParserCache;
+    use std::io::Write;
+    use tree_sitter::{Query, StreamingIterator};
+
+    fn temp_file(name: &str, content: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join("carv-test-queries");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        path
+    }
+
+    /// Run a query and return a sorted list of capture names.
+    fn collect_captures(lang: Language, tree: &tree_sitter::Tree, content: &[u8]) -> Vec<String> {
+        let query_src = query_for_language(lang);
+        let language = language_grammar(lang);
+        let query = Query::new(&language, query_src).unwrap();
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut captures: Vec<String> = Vec::new();
+        let mut matches = cursor.matches(&query, tree.root_node(), content);
+        while let Some(m) = matches.next() {
+            for cap in m.captures {
+                captures.push(query.capture_names()[cap.index as usize].to_string());
+            }
+        }
+        captures.sort();
+        captures
+    }
+
+    #[test]
+    fn rust_queries_capture_functions() {
+        let path = temp_file("query_rust.rs", "fn hello() {}\nfn world() {}\n");
+        let mut cache = ParserCache::new();
+        let tree = cache.parse_file(&path).unwrap();
+        let content = std::fs::read(&path).unwrap();
+
+        let captures = collect_captures(Language::Rust, &tree, &content);
+        let def_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.function")
+            .count();
+        assert_eq!(
+            def_count, 2,
+            "expected 2 function definitions, got: {:?}",
+            captures
+        );
+    }
+
+    #[test]
+    fn rust_queries_capture_structs() {
+        let path = temp_file("query_struct.rs", "struct Foo {}\nstruct Bar {}\n");
+        let mut cache = ParserCache::new();
+        let tree = cache.parse_file(&path).unwrap();
+        let content = std::fs::read(&path).unwrap();
+
+        let captures = collect_captures(Language::Rust, &tree, &content);
+        let def_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.struct")
+            .count();
+        assert!(
+            def_count >= 2,
+            "expected at least 2 struct definitions, got {}",
+            def_count
+        );
+    }
+
+    #[test]
+    fn python_queries_capture_functions_and_classes() {
+        let content_str = "def foo():\n    pass\n\nclass Bar:\n    def baz(self):\n        pass\n";
+        let path = temp_file("query_py.py", content_str);
+        let mut cache = ParserCache::new();
+        let tree = cache.parse_file(&path).unwrap();
+        let content = std::fs::read(&path).unwrap();
+
+        let captures = collect_captures(Language::Python, &tree, &content);
+        let fn_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.function")
+            .count();
+        let class_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.class")
+            .count();
+        assert!(
+            fn_count >= 2,
+            "expected at least 2 function defs, got: {:?}",
+            captures
+        );
+        assert!(
+            class_count >= 1,
+            "expected at least 1 class def, got: {:?}",
+            captures
+        );
+    }
+
+    #[test]
+    fn typescript_queries_capture_function_and_class() {
+        let content_str = "function hello() {}\nclass World {}\n";
+        let path = temp_file("query_ts.ts", content_str);
+        let mut cache = ParserCache::new();
+        let tree = cache.parse_file(&path).unwrap();
+        let content = std::fs::read(&path).unwrap();
+
+        let captures = collect_captures(Language::TypeScript, &tree, &content);
+        let fn_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.function")
+            .count();
+        let class_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.class")
+            .count();
+        assert!(
+            fn_count >= 1,
+            "expected at least 1 function def, got: {:?}",
+            captures
+        );
+        assert!(
+            class_count >= 1,
+            "expected at least 1 class def, got: {:?}",
+            captures
+        );
+    }
+}

--- a/src/treesitter/queries/mod.rs
+++ b/src/treesitter/queries/mod.rs
@@ -82,21 +82,34 @@ mod tests {
     }
 
     #[test]
-    fn rust_queries_capture_structs() {
-        let path = temp_file("query_struct.rs", "struct Foo {}\nstruct Bar {}\n");
+    fn rust_queries_capture_all_definition_types() {
+        // Covers struct, enum, union, trait, impl, type, macro, module, const, static.
+        let content_str = "struct S {}\nenum E {}\nunion U {}\ntrait T {}\nimpl T for S {}\ntype A = u8;\nmod m {}\npub const C: u8 = 0;\npub static S2: u8 = 0;\nmacro_rules! M { () => {} }\n";
+        let path = temp_file("query_all_rs.rs", content_str);
         let mut cache = ParserCache::new();
         let tree = cache.parse_file(&path).unwrap();
         let content = std::fs::read(&path).unwrap();
 
         let captures = collect_captures(Language::Rust, &tree, &content);
-        let def_count = captures
-            .iter()
-            .filter(|c| c.as_str() == "definition.struct")
-            .count();
+        let count = |name: &str| captures.iter().filter(|c| c.as_str() == name).count();
+
+        assert_eq!(count("definition.struct"), 1, "struct");
+        assert_eq!(count("definition.enum"), 1, "enum");
+        assert_eq!(count("definition.union"), 1, "union");
+        assert_eq!(count("definition.trait"), 1, "trait");
         assert!(
-            def_count >= 2,
-            "expected at least 2 struct definitions, got {}",
-            def_count
+            count("definition.impl") >= 1,
+            "impl (expected at least 1, got {})",
+            count("definition.impl")
+        );
+        assert_eq!(count("definition.type"), 1, "type alias");
+        assert_eq!(count("definition.module"), 1, "module");
+        assert_eq!(count("definition.constant"), 2, "const + static");
+        assert_eq!(
+            count("definition.macro"),
+            1,
+            "macro_rules, got: {:?}",
+            captures
         );
     }
 
@@ -117,16 +130,12 @@ mod tests {
             .iter()
             .filter(|c| c.as_str() == "definition.class")
             .count();
-        assert!(
-            fn_count >= 2,
-            "expected at least 2 function defs, got: {:?}",
+        assert_eq!(
+            fn_count, 2,
+            "expected 2 function defs (foo + baz), got: {:?}",
             captures
         );
-        assert!(
-            class_count >= 1,
-            "expected at least 1 class def, got: {:?}",
-            captures
-        );
+        assert_eq!(class_count, 1, "expected 1 class def, got: {:?}", captures);
     }
 
     #[test]
@@ -146,15 +155,7 @@ mod tests {
             .iter()
             .filter(|c| c.as_str() == "definition.class")
             .count();
-        assert!(
-            fn_count >= 1,
-            "expected at least 1 function def, got: {:?}",
-            captures
-        );
-        assert!(
-            class_count >= 1,
-            "expected at least 1 class def, got: {:?}",
-            captures
-        );
+        assert_eq!(fn_count, 1, "expected 1 function def, got: {:?}", captures);
+        assert_eq!(class_count, 1, "expected 1 class def, got: {:?}", captures);
     }
 }

--- a/src/treesitter/queries/mod.rs
+++ b/src/treesitter/queries/mod.rs
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn rust_queries_capture_all_definition_types() {
         // Covers struct, enum, union, trait, impl, type, macro, module, const, static.
-        let content_str = "struct S {}\nenum E {}\nunion U {}\ntrait T {}\nimpl T for S {}\ntype A = u8;\nmod m {}\npub const C: u8 = 0;\npub static S2: u8 = 0;\nmacro_rules! M { () => {} }\n";
+        let content_str = "struct S {}\nenum E {}\nunion U {}\ntrait T {}\nimpl T for S {}\ntype A = u8;\nmod m {}\npub const C: u8 = 0;\npub static S2: u8 = 0;\nmacro_rules! M { () => {} }\nfn free_func() {}\n";
         let path = temp_file("query_all_rs.rs", content_str);
         let mut cache = ParserCache::new();
         let tree = cache.parse_file(&path).unwrap();
@@ -93,6 +93,7 @@ mod tests {
         let captures = collect_captures(Language::Rust, &tree, &content);
         let count = |name: &str| captures.iter().filter(|c| c.as_str() == name).count();
 
+        assert_eq!(count("definition.function"), 1, "free function");
         assert_eq!(count("definition.struct"), 1, "struct");
         assert_eq!(count("definition.enum"), 1, "enum");
         assert_eq!(count("definition.union"), 1, "union");
@@ -130,12 +131,21 @@ mod tests {
             .iter()
             .filter(|c| c.as_str() == "definition.class")
             .count();
+        let method_count = captures
+            .iter()
+            .filter(|c| c.as_str() == "definition.method")
+            .count();
         assert_eq!(
-            fn_count, 2,
-            "expected 2 function defs (foo + baz), got: {:?}",
+            fn_count, 1,
+            "expected 1 function def (foo only, baz is a method), got: {:?}",
             captures
         );
         assert_eq!(class_count, 1, "expected 1 class def, got: {:?}", captures);
+        assert_eq!(
+            method_count, 1,
+            "expected 1 method def (baz), got: {:?}",
+            captures
+        );
     }
 
     #[test]

--- a/src/treesitter/queries/python.scm
+++ b/src/treesitter/queries/python.scm
@@ -46,11 +46,11 @@
       attribute: (identifier) @name.reference)
   ]) @reference.call
 
-; Import statements.
+; Import statements — capture the imported name as a reference.
 (import_statement
   name: (dotted_name
-    (identifier) @name.reference)) @reference.call
+    (identifier) @name.reference))
 
 (import_from_statement
   module_name: (dotted_name
-    (identifier) @name.reference)) @reference.call
+    (identifier) @name.reference))

--- a/src/treesitter/queries/python.scm
+++ b/src/treesitter/queries/python.scm
@@ -7,8 +7,11 @@
 ; Definitions
 ; ---------------------------------------------------------------------------
 
-(function_definition
-  name: (identifier) @name.definition.function) @definition.function
+; Module-level function definitions — scoped to avoid capturing methods
+; inside class bodies (those are handled by the class-body pattern below).
+(module
+  (function_definition
+    name: (identifier) @name.definition.function) @definition.function)
 
 (class_definition
   name: (identifier) @name.definition.class) @definition.class

--- a/src/treesitter/queries/python.scm
+++ b/src/treesitter/queries/python.scm
@@ -1,0 +1,56 @@
+; Python tree-sitter query file for carv.
+; Captures definitions and references for structural tools.
+;
+; Based on tree-sitter-python 0.25.0 grammar node types.
+
+; ---------------------------------------------------------------------------
+; Definitions
+; ---------------------------------------------------------------------------
+
+(function_definition
+  name: (identifier) @name.definition.function) @definition.function
+
+(class_definition
+  name: (identifier) @name.definition.class) @definition.class
+
+; Top-level constants and variables.
+(module
+  (expression_statement
+    (assignment
+      left: (identifier) @name.definition.constant)) @definition.constant)
+
+; Method definitions inside a class body.
+(class_definition
+  body: (block
+    (function_definition
+      name: (identifier) @name.definition.method) @definition.method))
+
+; Decorated functions / methods.
+(decorated_definition
+  definition: (function_definition
+    name: (identifier) @name.definition.function) @definition.function)
+
+(decorated_definition
+  definition: (class_definition
+    name: (identifier) @name.definition.class) @definition.class)
+
+; ---------------------------------------------------------------------------
+; References
+; ---------------------------------------------------------------------------
+
+; Function / method calls.
+(call
+  function: [
+    (identifier) @name.reference
+    (attribute
+      attribute: (identifier) @name.reference)
+  ]) @reference.call
+
+; Import statements.
+(import_statement
+  name: (dotted_name
+    (identifier) @name.reference)) @reference.call
+
+(import_from_statement
+  module_name: (dotted_name
+    (identifier) @name.reference)) @reference.call

--- a/src/treesitter/queries/rust.scm
+++ b/src/treesitter/queries/rust.scm
@@ -22,11 +22,11 @@
 
 ; Enum definitions.
 (enum_item
-  name: (type_identifier) @name.definition.struct) @definition.struct
+  name: (type_identifier) @name.definition.enum) @definition.enum
 
 ; Union definitions.
 (union_item
-  name: (type_identifier) @name.definition.struct) @definition.struct
+  name: (type_identifier) @name.definition.union) @definition.union
 
 ; Trait definitions.
 (trait_item
@@ -39,7 +39,7 @@
 
 ; Type aliases.
 (type_item
-  name: (type_identifier) @name.definition.struct) @definition.struct
+  name: (type_identifier) @name.definition.type) @definition.type
 
 ; Macro definitions.
 (macro_definition
@@ -69,7 +69,3 @@
 
 (macro_invocation
   macro: (identifier) @name.reference) @reference.call
-
-; Field access — struct field references.
-(field_expression
-  field: (field_identifier) @name.reference) @reference.call

--- a/src/treesitter/queries/rust.scm
+++ b/src/treesitter/queries/rust.scm
@@ -1,0 +1,75 @@
+; Rust tree-sitter query file for carv.
+; Captures definitions and references for structural tools (get_skeleton,
+; get_function, replace_symbol).
+;
+; Based on tree-sitter-rust 0.24.2 grammar node types.
+
+; ---------------------------------------------------------------------------
+; Definitions
+; ---------------------------------------------------------------------------
+
+(function_item
+  name: (identifier) @name.definition.function) @definition.function
+
+; Method definitions (inside impl blocks).
+(declaration_list
+  (function_item
+    name: (identifier) @name.definition.method) @definition.method)
+
+; Struct definitions.
+(struct_item
+  name: (type_identifier) @name.definition.struct) @definition.struct
+
+; Enum definitions.
+(enum_item
+  name: (type_identifier) @name.definition.struct) @definition.struct
+
+; Union definitions.
+(union_item
+  name: (type_identifier) @name.definition.struct) @definition.struct
+
+; Trait definitions.
+(trait_item
+  name: (type_identifier) @name.definition.trait) @definition.trait
+
+; Impl blocks.
+(impl_item
+  trait: (_)? @name.definition.impl
+  type: (type_identifier) @name.definition.impl) @definition.impl
+
+; Type aliases.
+(type_item
+  name: (type_identifier) @name.definition.struct) @definition.struct
+
+; Macro definitions.
+(macro_definition
+  name: (identifier) @name.definition.macro) @definition.macro
+
+; Module definitions.
+(mod_item
+  name: (identifier) @name.definition.module) @definition.module
+
+; Constant / static definitions.
+(const_item
+  name: (identifier) @name.definition.constant) @definition.constant
+
+(static_item
+  name: (identifier) @name.definition.constant) @definition.constant
+
+; ---------------------------------------------------------------------------
+; References
+; ---------------------------------------------------------------------------
+
+(call_expression
+  function: (identifier) @name.reference) @reference.call
+
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @name.reference)) @reference.call
+
+(macro_invocation
+  macro: (identifier) @name.reference) @reference.call
+
+; Field access — struct field references.
+(field_expression
+  field: (field_identifier) @name.reference) @reference.call

--- a/src/treesitter/queries/rust.scm
+++ b/src/treesitter/queries/rust.scm
@@ -8,8 +8,11 @@
 ; Definitions
 ; ---------------------------------------------------------------------------
 
-(function_item
-  name: (identifier) @name.definition.function) @definition.function
+; Free functions — scoped to source_file to avoid capturing methods
+; inside impl blocks (those are handled by the declaration_list pattern).
+(source_file
+  (function_item
+    name: (identifier) @name.definition.function) @definition.function)
 
 ; Method definitions (inside impl blocks).
 (declaration_list
@@ -32,9 +35,8 @@
 (trait_item
   name: (type_identifier) @name.definition.trait) @definition.trait
 
-; Impl blocks.
+; Impl blocks — captures the type being implemented.
 (impl_item
-  trait: (_)? @name.definition.impl
   type: (type_identifier) @name.definition.impl) @definition.impl
 
 ; Type aliases.

--- a/src/treesitter/queries/typescript.scm
+++ b/src/treesitter/queries/typescript.scm
@@ -1,0 +1,76 @@
+; TypeScript / TSX tree-sitter query file for carv.
+; Captures definitions and references for structural tools.
+;
+; Based on tree-sitter-typescript 0.23.2 grammar node types.
+
+; ---------------------------------------------------------------------------
+; Definitions
+; ---------------------------------------------------------------------------
+
+; Function declarations and arrow functions assigned to variables.
+(function_declaration
+  name: (identifier) @name.definition.function) @definition.function
+
+; Method definitions in classes / object literals.
+(method_definition
+  name: (property_identifier) @name.definition.method) @definition.method
+
+; Class declarations.
+(class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+; Abstract class declarations.
+(abstract_class_declaration
+  name: (type_identifier) @name.definition.class) @definition.class
+
+; Interface declarations.
+(interface_declaration
+  name: (type_identifier) @name.definition.interface) @definition.interface
+
+; Variable declarations with arrow functions (const foo = () => {}).
+(lexical_declaration
+  (variable_declarator
+    name: (identifier) @name.definition.function
+    value: [
+      (arrow_function)
+      (function_expression)
+    ]) @definition.function)
+
+; Exported declarations.
+(export_statement
+  declaration: [
+    (function_declaration
+      name: (identifier) @name.definition.function) @definition.function
+    (class_declaration
+      name: (type_identifier) @name.definition.class) @definition.class
+    (interface_declaration
+      name: (type_identifier) @name.definition.interface) @definition.interface
+    (lexical_declaration
+      (variable_declarator
+        name: (identifier) @name.definition.function
+        value: (arrow_function)) @definition.function)
+  ])
+
+; Type aliases.
+(type_alias_declaration
+  name: (type_identifier) @name.definition.struct) @definition.struct
+
+; Enum declarations.
+(enum_declaration
+  name: (identifier) @name.definition.struct) @definition.struct
+
+; ---------------------------------------------------------------------------
+; References
+; ---------------------------------------------------------------------------
+
+; Function / method calls.
+(call_expression
+  function: [
+    (identifier) @name.reference
+    (member_expression
+      property: (property_identifier) @name.reference)
+  ]) @reference.call
+
+; New expressions (class instantiation).
+(new_expression
+  constructor: (identifier) @name.reference) @reference.call

--- a/src/treesitter/queries/typescript.scm
+++ b/src/treesitter/queries/typescript.scm
@@ -53,11 +53,11 @@
 
 ; Type aliases.
 (type_alias_declaration
-  name: (type_identifier) @name.definition.struct) @definition.struct
+  name: (type_identifier) @name.definition.type) @definition.type
 
 ; Enum declarations.
 (enum_declaration
-  name: (identifier) @name.definition.struct) @definition.struct
+  name: (identifier) @name.definition.enum) @definition.enum
 
 ; ---------------------------------------------------------------------------
 ; References

--- a/src/treesitter/queries/typescript.scm
+++ b/src/treesitter/queries/typescript.scm
@@ -36,20 +36,9 @@
       (function_expression)
     ]) @definition.function)
 
-; Exported declarations.
-(export_statement
-  declaration: [
-    (function_declaration
-      name: (identifier) @name.definition.function) @definition.function
-    (class_declaration
-      name: (type_identifier) @name.definition.class) @definition.class
-    (interface_declaration
-      name: (type_identifier) @name.definition.interface) @definition.interface
-    (lexical_declaration
-      (variable_declarator
-        name: (identifier) @name.definition.function
-        value: (arrow_function)) @definition.function)
-  ])
+; Note: `export_statement` wrappers are not repeated here — tree-sitter
+; already matches the inner declaration patterns through the wrapper.
+; This avoids double-capturing the same node.
 
 ; Type aliases.
 (type_alias_declaration


### PR DESCRIPTION
## Summary
G3-G4: Tree-sitter S-expression query files with definition/reference captures. Embedded via include_str!().

## Files
- **rust.scm** — function, method, struct, enum, union, trait, impl, type alias, macro, module, constant/static definitions + call references
- **python.scm** — function, class, method, constant definitions + call references
- **typescript.scm** — function, method, class, interface, type alias, enum, arrow-function variable definitions + call references
- **queries/mod.rs** — query_for_language() dispatcher + 4 integration tests

## Capture names
- @definition.function
- @definition.method
- @definition.struct
- @definition.class
- @definition.interface
- @definition.trait
- @definition.impl
- @definition.macro
- @definition.module
- @definition.constant
- @name.definition.* (for name extraction in G5)
- @name.reference + @reference.call

## Verification
- [x] cargo build ✅
- [x] cargo test (248/248) ✅
- [x] cargo clippy ✅
- [x] cargo fmt ✅

Closes #32