### PR TITLE
fix(agents): add Pre-Write Gate + edit/write permission guard for rust-expert

### DIFF
--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -266,6 +266,18 @@ Exception: FORMULAIC tasks can skip the scout since they're template-based and d
 
 After the scout returns for a FORMULAIC or IMPLEMENT task, **the expert MUST delegate to `rust-coder`.** Do not start writing code. The expert's role is classification + scout context assembly — not implementation. If you find yourself reaching for `edit` or `write` on a FORMULAIC/IMPLEMENT task, stop and delegate. This gate exists because the expert model is expensive and should only write code for DENSE work (state machines, retry logic, parsing, error flow).
 
+### Pre-Write Gate (MANDATORY — run before calling edit / write / bash for code)
+
+Before every call to `edit`, `write`, or any code-modifying `bash` command, verify:
+
+- [ ] **Classification check:** Is this task FORMULAIC or IMPLEMENT?
+  → If **yes**: STOP. Do not write code. Delegate to `rust-coder` instead.
+  → If **no** (it's DENSE or DESIGN): proceed.
+
+This gate fires on EVERY code change. If you catch yourself reaching for the editor,
+pause and classify first. The cost of skipping this gate is the entire session's
+efficiency — the pro model burns tokens on work the flash model does equally well.
+
 ### Delegation Format
 
 When delegating to a subagent, always include:

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -15,7 +15,9 @@
     "rust-expert": {
       "model": "deepseek/deepseek-v4-pro",
       "permission": {
-        "lsp": "allow"
+        "lsp": "allow",
+        "edit": "ask",
+        "write": "ask"
       }
     },
     "rust-coder": {


### PR DESCRIPTION
## Summary
Prevent the expensive rust-expert model from writing code on non-DENSE tasks. Two-layer enforcement:

### 1. Prompt-level gate (rust-expert.md)
New **Pre-Write Gate** section fires before every edit/write/bash call:
- Is this FORMULAIC or IMPLEMENT? → STOP, delegate to rust-coder
- Is this DENSE? → proceed

### 2. Permission constraint (opencode.json)
rust-expert now has `edit: ask`, `write: ask` — forces a confirmation prompt before file modification, creating a deliberate re-classification pause.

### Why
The expert wrote query files (FORMULAIC) and language registry (FORMULAIC) directly instead of delegating to rust-coder. Each violation costs tokens on the expensive pro model. The gate + permission combo makes delegation the default path for non-DENSE work.

### Requires
Session restart to take effect.