### PR TITLE
ci: add cargo-deny advisory check (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,12 @@
 #   - push to main
 #   - pull_request against all branches
 #
-# Jobs (4 gates in dependency order):
+# Jobs (4 gates + 1 advisory check):
 #   1. build   — cargo build --verbose (must pass before other jobs)
 #   2. test    — cargo test --verbose  (depends on build)
 #   3. clippy  — cargo clippy -- -D warnings (depends on build)
 #   4. fmt     — cargo fmt -- --check (depends on build, runs parallel with test/clippy)
+#   5. deny    — cargo deny check advisories (advisory only, no needs/depends)
 
 name: CI
 
@@ -69,3 +70,15 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
+
+  deny:
+    name: cargo deny check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: stable
+      - run: cargo install cargo-deny --locked
+      - run: cargo deny check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          rust-version: stable
-      - run: cargo install cargo-deny --locked
-      - run: cargo deny check advisories
+          command: check advisories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          command: check advisories
+          rust-version: stable
+      - run: cargo install cargo-deny --locked
+      - run: cargo deny check advisories

--- a/deny.toml
+++ b/deny.toml
@@ -9,9 +9,9 @@
 [advisories]
 # Advisory-only mode: informational, not a hard gate.
 # Set db-urls if needed behind a corporate proxy.
-vulnerability = "warn"
-unmaintained = "warn"
-unsound = "warn"
+vulnerability = "deny"   # job fails (yellow) but continue-on-error keeps PR green
+unmaintained = "warn"    # lower signal, warn is fine here
+unsound      = "deny"
 notice = "warn"
 ignore = []
 
@@ -32,7 +32,7 @@ exceptions = []
 [bans]
 # Allow all crates. No bans.
 multiple-versions = "allow"
-wildcards = "allow"
+wildcards = "allow"       # TODO: tighten once [bans] is activated in CI
 highlight = "all"
 deny = []
 skip = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration for carv
+#
+# This is a permissive initial configuration. As the project matures,
+# tighten these policies (e.g., allow only specific licenses, ban
+# duplicate versions, block advisories).
+#
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Advisory-only mode: informational, not a hard gate.
+# Set db-urls if needed behind a corporate proxy.
+vulnerability = "warn"
+unmaintained = "warn"
+unsound = "warn"
+notice = "warn"
+ignore = []
+
+# NOTE: Only [advisories] is checked in CI currently. The sections
+# below are placeholders for future tightening.
+# --- Sections below are not checked in CI (cargo deny check advisories only) ---
+
+[licenses]
+# Allow all licenses; warn on unknown/unrecognized ones.
+unlicensed = "warn"
+allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "ISC", "Unlicense", "MPL-2.0", "Zlib"]
+deny = []
+copyleft = "allow"
+default = "warn"
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+# Allow all crates. No bans.
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+# Allow crates from crates.io, git repos, and local paths.
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
Add a `cargo-deny` advisory-only CI job and initial `deny.toml` with permissive defaults.

## Changes
- **ci.yml**: New `deny` job — runs `cargo deny check advisories` with `continue-on-error: true` (advisory-only, doesn't block merge)
- **deny.toml**: Permissive initial config — only `[advisories]` section is active in CI. License/bans/sources sections are placeholders for future tightening.

## Review
- ✅ rust-reviewer: Approved (mechanical review)
- ✅ rust-reviewer2: Approved (architectural review)
- All review findings (5 warnings) fixed in final commit

## DoD
- [x] cargo build ✅
- [x] cargo test (274 tests) ✅
- [x] cargo clippy -- -D warnings ✅
- [x] cargo fmt -- --check ✅
- [x] No new dependencies (CI-only)
- [x] No API changes
- [x] No security boundary changes
- [x] Diff: ~60 lines (well within 150-line FORMULAIC cap)

Closes #59