### PR TITLE
config(subagents): switch reviewer models to kimi-k2.7 + qwen3.7-max

### DIFF
--- a/.opencode/subagents/rust-reviewer.md
+++ b/.opencode/subagents/rust-reviewer.md
@@ -1,8 +1,8 @@
 ---
 name: rust-reviewer
 description: "Rust code review specialist. Reviews code for memory safety, async correctness, error handling, spec compliance, and performance."
+model: kimi-k2.7
 mode: subagent
-type: general
 tools:
   read: true
   glob: true

--- a/.opencode/subagents/rust-reviewer2.md
+++ b/.opencode/subagents/rust-reviewer2.md
@@ -1,6 +1,7 @@
 ---
 name: rust-reviewer2
 description: "Second-opinion Rust reviewer focusing on architectural coherence, spec compliance, invariants, and cross-module consistency. Complements the checklist-based reviewer."
+model: qwen3.7-max
 mode: subagent
 tools:
   read: true
@@ -15,7 +16,7 @@ tools:
 
 ## Relationship to rust-reviewer
 
-`rust-reviewer` (qwen3.6-plus) handles the mechanical checklist: serde annotations, missing derives, test coverage, error paths, tool output contracts. **Do not duplicate its work.**
+`rust-reviewer` (kimi-k2.7) handles the mechanical checklist: serde annotations, missing derives, test coverage, error paths, tool output contracts. **Do not duplicate its work.**
 
 `rust-reviewer2` (you) handles higher-level concerns that require reasoning across modules and against the design spec. Focus on what a checklist can't catch.
 


### PR DESCRIPTION
## Summary
Switch reviewer agent models to higher-capacity models:
- **rust-reviewer** → `kimi-k2.7` (was default/qwen3.6-plus)
- **rust-reviewer2** → `qwen3.7-max` (was default)

Also removes `type: general` from rust-reviewer (kimi models reject this field — known gotcha from MEMORY.md).