### PR TITLE
fix(config): replace kimi-k2.6 with valid model names

### DIFF
--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -71,7 +71,7 @@ Before executing any task, classify it into one of five tiers. **This determines
 | **EXPLORE** | `rust-scout` (qwen3.5-plus) | File finding, pattern discovery, detecting project structure |
 | **IMPLEMENT** | `rust-coder` (flash) | Feature implementation following existing patterns, tool impls, module wiring |
 | **DENSE** | `rust-expert` (pro) | SSE parsing state machines, anchor resolution + byte-range splicing, AST traversal, token budget math, complex error handling, retry/backoff logic |
-| **DESIGN** | `rust-architect` (kimi-k2.6) | Module boundaries, trait design, API contracts, concurrency models. **Requires user approval first.** |
+| **DESIGN** | `rust-architect` (kimi-k2.7-code) | Module boundaries, trait design, API contracts, concurrency models. **Requires user approval first.** |
 | **REVIEW** | `rust-reviewer` + `rust-reviewer2` (parallel) | Checklist review + architectural review; delegate to both simultaneously |
 
 ### Classification Decision Tree

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -45,13 +45,13 @@
       }
     },
     "rust-architect": {
-      "model": "opencode-go/kimi-k2.6",
+      "model": "opencode-go/kimi-k2.7-code",
       "permission": {
         "lsp": "allow"
       }
     },
     "rust-reviewer2": {
-      "model": "opencode-go/kimi-k2.6",
+      "model": "opencode-go/qwen3.7-max",
       "permission": {
         "lsp": "allow"
       }


### PR DESCRIPTION
## Summary
Fix the kimi model references in agent config — `kimi-k2.6` doesn't exist.

## Changes
| Agent | Before | After |
|-------|--------|-------|
| rust-architect | kimi-k2.6 | kimi-k2.7-code |
| rust-reviewer2 | kimi-k2.6 | qwen3.7-max |

## DoD Checklist
- [x] cargo build ✅
- [x] cargo test ✅
- [x] cargo clippy ✅
- [x] cargo fmt ✅
- [x] No new deps
- [x] No API changes
- [x] No security boundary changes

Closes #108