### PR TITLE
feat(review): layered review system — both reviewers cover full scope

### DIFF
--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -71,8 +71,8 @@ Before executing any task, classify it into one of five tiers. **This determines
 | **EXPLORE** | `rust-scout` (qwen3.5-plus) | File finding, pattern discovery, detecting project structure |
 | **IMPLEMENT** | `rust-coder` (flash) | Feature implementation following existing patterns, tool impls, module wiring |
 | **DENSE** | `rust-expert` (pro) | SSE parsing state machines, anchor resolution + byte-range splicing, AST traversal, token budget math, complex error handling, retry/backoff logic |
-| **DESIGN** | `rust-architect` (kimi-k2.6) | Module boundaries, trait design, API contracts, concurrency models. **Requires user approval first.** |
-| **REVIEW** | `rust-reviewer` + `rust-reviewer2` (parallel) | Checklist review + architectural review; delegate to both simultaneously |
+| **DESIGN** | `rust-architect` (kimi-k2.7-code) | Module boundaries, trait design, API contracts, concurrency models. **Requires user approval first.** |
+| **REVIEW** | `rust-reviewer` (minimax-m3) + `rust-reviewer2` (kimi-k2.7-code) (parallel) | Full review — duplex layers (same scope, different model lenses); delegate to both simultaneously |
 
 ### Classification Decision Tree
 
@@ -151,7 +151,7 @@ Always classify the task first using the decision tree above. Then route to the 
 | IMPLEMENT | `rust-coder` | Delegate — code generation with scout context |
 | DENSE | none (rust-expert) | Handle directly — state machines, parsing, error flow |
 | DESIGN | `rust-architect` | Escalate — only after user approval |
-| REVIEW | `rust-reviewer` + `rust-reviewer2` | Delegate to both in parallel — checklist review + architectural review. See Parallel Review section. |
+| REVIEW | `rust-reviewer` (minimax-m3) + `rust-reviewer2` (kimi-k2.7-code) | Delegate to both in parallel — full review, duplex layers (same scope, different model lenses). See Parallel Review section. |
 
 ### Review Fix Router (MANDATORY — apply when receiving review feedback)
 
@@ -232,15 +232,15 @@ After **3 review rounds** on a single PR:
 
 ### Parallel Review (MANDATORY for REVIEW tier)
 
-When a PR reaches the REVIEW stage, delegate to **both** reviewers simultaneously:
+When a PR reaches the REVIEW stage, delegate to **both** reviewers simultaneously for **layered review**:
 
-1. **Delegate to `rust-reviewer`** — checklist-based review (serde annotations, missing derives, test coverage, error paths, tool output contracts)
-2. **Delegate to `rust-reviewer2`** — architectural review (spec/invariant compliance, cross-module consistency, security boundaries, async correctness)
+1. **Delegate to `rust-reviewer` (minimax-m3)** — full-scope review (layer 1): mechanical checks, spec compliance, test coverage, error paths, tool output contracts, security boundaries
+2. **Delegate to `rust-reviewer2` (kimi-k2.7-code)** — full-scope review (layer 2): same surface as layer 1, but through a different model lens for complementary coverage
 3. **Wait for both** to return findings
 4. **Merge and deduplicate** findings into a single report. Critical issues from either reviewer block the PR.
 5. **Route fixes** according to the Review Fix Router
 
-Do NOT run reviewers sequentially. The two reviews cover different concerns and run in parallel for speed.
+Do NOT run reviewers sequentially. Both cover the full review scope in parallel for speed. Different model lenses catch different issues on the same surface — this is more robust than dividing responsibility by concern.
 
 **Divergence protocol:** If the two reviewers flag contradictory issues (e.g., one says "extract to trait" and the other says "keep inline"), escalate to `rust-expert` to decide. The expert's ruling is final for that review cycle.
 
@@ -301,12 +301,12 @@ task(
 
 ### rust-architect Escalation
 
-Before delegating to `rust-architect` (Kimi K2.6, expensive):
+Before delegating to `rust-architect` (Kimi K2.7-code, expensive):
 1. Assess if the task truly needs high-level design (module boundaries, trait design, API contracts)
 2. If yes, **ask the user for approval**:
    ```
    This task involves [specific design decision]. I recommend escalating to rust-architect
-   (Kimi K2.6) for high-level design. Approve? (yes/no)
+   (Kimi K2.7-code) for high-level design. Approve? (yes/no)
    ```
 3. Only delegate after user approval
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -27,7 +27,7 @@
       }
     },
     "rust-reviewer": {
-      "model": "opencode-go/qwen3.6-plus",
+      "model": "opencode-go/minimax-m3",
       "permission": {
         "lsp": "allow"
       }
@@ -51,7 +51,7 @@
       }
     },
     "rust-reviewer2": {
-      "model": "opencode-go/kimi-k2.6",
+      "model": "opencode-go/kimi-k2.7-code",
       "permission": {
         "lsp": "allow"
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ git cat-file -p HEAD | grep -A10 "BEGIN SSH SIGNATURE"
 **Two-step review before every PR:**
 
 1. **Agent verifies the checklist** — the implementing agent (rust-expert or rust-coder) runs `cargo build / test / clippy / fmt` and checks all DoD items
-2. **rust-reviewer verifies the agent's work** — delegate to the reviewer subagent (qwen3.6-plus) for mechanical verification of the DoD checklist
+2. **Both reviewers verify the agent's work** — delegate to `rust-reviewer` (minimax-m3, layer 1) and `rust-reviewer2` (kimi-k2.7-code, layer 2) for full-scope review. Both cover the complete DoD checklist and depth standards.
 3. **PR created directly** — after reviewer approval, create the PR immediately (no pre-PR user sign-off)
 
 Do NOT proceed to PR creation until the reviewer agent signs off.
@@ -345,7 +345,7 @@ These files are a distinct review category from Rust code. Don't review them lik
 
 ## Review Depth Standards
 
-The reviewer (rust-reviewer) must go beyond mechanical DoD checks. These apply to all PRs:
+Both reviewers must go beyond mechanical DoD checks. Each covers the full scope below through a different model lens — this layered approach catches more issues than either reviewer alone:
 
 ### For all PRs
 - Read every line of the diff. Do not skim.


### PR DESCRIPTION
## Summary
Switch from split-responsibility review (checklist vs architectural) to layered review (both reviewers cover full scope with different models), matching the flux project pattern.

## Changes
| Agent | Before | After | Role |
|-------|--------|-------|------|
| rust-reviewer | qwen3.6-plus | minimax-m3 | Full review (layer 1) |
| rust-reviewer2 | kimi-k2.6 | kimi-k2.7-code | Full review (layer 2) |

Also fixed stale kimi-k2.6 → kimi-k2.7-code in rust-expert routing table.

## Doc updates
- rust-expert.md: Parallel Review section — both cover full scope
- AGENTS.md: Review Depth Standards — layered approach
- MEMORY.md: design decision recorded

## DoD Checklist
- [x] cargo build ✅
- [x] cargo test ✅
- [x] cargo clippy ✅
- [x] cargo fmt ✅
- [x] No new deps
- [x] No API changes
- [x] No security boundary changes

Closes #110
Supersedes #108 / PR #109