### PR TITLE
docs(agent): add documentation review routing to rust-expert

### DIFF
--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -248,7 +248,7 @@ Do NOT run reviewers sequentially. Both cover the full review scope in parallel 
 
 For PRs that **only modify documentation files** (`.md` files, rustdoc comments, README, CONTRIBUTING, etc.), use a **single reviewer** instead of the parallel dual-reviewer approach:
 
-1. **Delegate to `rust-reviewer` only** — skip `rust-reviewer2` (architectural review is overkill for docs)
+1. **Delegate to `rust-reviewer` only** — skip `rust-reviewer2` (layer 2 review is overkill for docs)
 2. **Use a doc-focused prompt** with these criteria:
    - **Accuracy**: Does the documentation match the actual codebase behavior?
    - **Completeness**: Are all sections present? Missing information?

--- a/.opencode/agents/rust-expert.md
+++ b/.opencode/agents/rust-expert.md
@@ -230,7 +230,7 @@ After **3 review rounds** on a single PR:
 
 - Blocking findings (correctness, security, memory safety) are exceptions — always fix.
 
-### Parallel Review (MANDATORY for REVIEW tier)
+### Parallel Review (MANDATORY for code PRs)
 
 When a PR reaches the REVIEW stage, delegate to **both** reviewers simultaneously for **layered review**:
 
@@ -243,6 +243,29 @@ When a PR reaches the REVIEW stage, delegate to **both** reviewers simultaneousl
 Do NOT run reviewers sequentially. Both cover the full review scope in parallel for speed. Different model lenses catch different issues on the same surface — this is more robust than dividing responsibility by concern.
 
 **Divergence protocol:** If the two reviewers flag contradictory issues (e.g., one says "extract to trait" and the other says "keep inline"), escalate to `rust-expert` to decide. The expert's ruling is final for that review cycle.
+
+### Documentation Review (MODIFIED for doc-only PRs)
+
+For PRs that **only modify documentation files** (`.md` files, rustdoc comments, README, CONTRIBUTING, etc.), use a **single reviewer** instead of the parallel dual-reviewer approach:
+
+1. **Delegate to `rust-reviewer` only** — skip `rust-reviewer2` (architectural review is overkill for docs)
+2. **Use a doc-focused prompt** with these criteria:
+   - **Accuracy**: Does the documentation match the actual codebase behavior?
+   - **Completeness**: Are all sections present? Missing information?
+   - **Clarity**: Would a new user understand this?
+   - **Formatting**: Markdown syntax, links, code blocks, headings hierarchy
+   - **Consistency**: Terminology matches codebase (e.g., "carv" not "Carve", correct tool names)
+3. **Skip code-specific checks** — no serde annotations, no panic checks, no async safety, no test coverage requirements
+4. **No Pre-Review Self-Check** needed for doc-only PRs (the code-focused checklist doesn't apply)
+
+**How to detect doc-only PRs:**
+- Check `git diff --stat` — if only `.md` files changed, it's a doc PR
+- Rustdoc changes (`.rs` files with only `///` comment changes) also count as doc PRs
+
+**When to use full parallel review:**
+- PRs that mix code + docs
+- PRs that change API contracts (even if documented)
+- PRs that modify architecture diagrams or spec compliance sections
 
 ### Merge Gate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@ git cat-file -p HEAD | grep -A10 "BEGIN SSH SIGNATURE"
 
 1. **Agent verifies the checklist** — the implementing agent (rust-expert or rust-coder) runs `cargo build / test / clippy / fmt` and checks all DoD items
 2. **Both reviewers verify the agent's work** — delegate to `rust-reviewer` (minimax-m3, layer 1) and `rust-reviewer2` (kimi-k2.7-code, layer 2) for full-scope review. Both cover the complete DoD checklist and depth standards.
+   - **Exception:** doc-only PRs use single-reviewer routing — see `rust-expert` §Documentation Review
 3. **PR created directly** — after reviewer approval, create the PR immediately (no pre-PR user sign-off)
 
 Do NOT proceed to PR creation until the reviewer agent signs off.


### PR DESCRIPTION
## Summary
Add a 'Documentation Review' section to the rust-expert agent definition that routes doc-only PRs to a single reviewer (rust-reviewer) with doc-specific criteria, instead of the full dual-reviewer parallel review.

## Changes
- Renamed 'Parallel Review (MANDATORY for REVIEW tier)' to 'Parallel Review (MANDATORY for code PRs)'
- Added 'Documentation Review (MODIFIED for doc-only PRs)' section with:
  - Single reviewer routing (rust-reviewer only)
  - Doc-focused criteria (accuracy, completeness, clarity, formatting, consistency)
  - Skip code-specific checks (serde, panics, async safety, test coverage)
  - Detection rules for doc-only PRs
  - When to use full parallel review (mixed code+docs, API changes, architecture)

## DoD Checklist
- [x] cargo build ✅
- [x] cargo test ✅ (311 passed)
- [x] cargo clippy -- -D warnings ✅
- [x] cargo fmt -- --check ✅
- [x] No new dependencies
- [x] No public API changes
- [x] No security boundary changes
- [x] Design doc consistent (N/A - agent config only)
- [x] No new code (config change only)
- [x] Error handling N/A
- [x] Diff within line cap (24 lines added)

Closes #129