### PR TITLE
fix(docs): repair 9 broken intra-doc links

### DIFF
--- a/src/hashing/state.rs
+++ b/src/hashing/state.rs
@@ -69,14 +69,14 @@ impl AnchorState {
     /// Invalidate the cached anchors for `path`.
     ///
     /// Call this after any write/edit tool modifies a file. The next
-    /// call to [`get_anchors`] will re-read the file from disk and
+    /// call to [`AnchorState::get_anchors`] will re-read the file from disk and
     /// recompute anchors.
     pub fn notify_edit(&mut self, path: &Path) {
         self.files.remove(path);
     }
 
     /// Remove a file from anchor tracking entirely (e.g., after
-    /// deletion). Same effect as [`notify_edit`] but semantically
+    /// deletion). Same effect as [`AnchorState::notify_edit`] but semantically
     /// clearer for file deletions.
     pub fn remove(&mut self, path: &Path) {
         self.files.remove(path);

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -2,14 +2,14 @@
 //!
 //! Each provider (Anthropic, OpenAI) implements this trait to expose a
 //! unified streaming chat interface. The agent loop calls `stream_chat` and
-//! consumes [`LlmEvent`] items without knowing which backend is in use.
+//! consumes [`crate::llm::types::LlmEvent`] items without knowing which backend is in use.
 //!
 //! ## Design
 //! - Boxed-future return type (not RPITIT) keeps the trait **object-safe**,
 //!   so callers can hold `dyn LlmProvider` behind an `Arc`.  This is the same
 //!   pattern used by [`StreamOutput`](crate::stream::output::StreamOutput).
 //! - No `async-trait` crate — the boxed future is explicit.
-//! - The [`LlmStream`] and [`LlmStreamFuture`] aliases (from
+//! - The [`crate::llm::types::LlmStream`] and [`LlmStreamFuture`] aliases (from
 //!   [`crate::llm::types`]) keep the signature concise.
 //! - Errors are returned via `anyhow::Result` at both the stream and item levels.
 
@@ -19,7 +19,7 @@ use crate::llm::types::{LlmStreamFuture, Message, RequestConfig, ToolDef};
 ///
 /// Implementations handle the provider-specific wire protocol (SSE event
 /// parsing, authentication, request formatting) and emit a unified stream
-/// of [`LlmEvent`] items.
+/// of [`crate::llm::types::LlmEvent`] items.
 ///
 /// ## Object safety
 /// This trait is object-safe — you can use `Arc<dyn LlmProvider>` in the
@@ -29,7 +29,7 @@ pub trait LlmProvider: Send + Sync {
     /// Start a streaming chat completion.
     ///
     /// Returns a [`LlmStreamFuture`] — a pinned, boxed, sendable future that
-    /// resolves to a [`LlmStream`]. Each item in the stream is a single delta:
+    /// resolves to a [`crate::llm::types::LlmStream`]. Each item in the stream is a single delta:
     /// text tokens, thinking tokens, tool-use fragments, or terminal signals
     /// (`Done`, `Error`).
     fn stream_chat(

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -262,7 +262,7 @@ pub struct LlmUsage {
 
 /// Sendable, pinned stream of [`LlmEvent`] items.
 ///
-/// Used as the return type of [`LlmProvider::stream_chat`]. Wrapping in `Pin`
+/// Used as the return type of [`crate::llm::provider::LlmProvider::stream_chat`]. Wrapping in `Pin`
 /// is required for async iteration, and boxing erases the concrete type so the
 /// trait remains object-safe.
 pub type LlmStream = Pin<Box<dyn Stream<Item = Result<LlmEvent>> + Send>>;

--- a/src/tools/edit.rs
+++ b/src/tools/edit.rs
@@ -1,6 +1,6 @@
 //! edit_file tool — anchor-based file editing.
 //!
-//! Uses stable word anchors (from [`read_file`]) to target edit locations.
+//! Uses stable word anchors (from [`crate::tools::fs::ReadFileTool`]) to target edit locations.
 //! Supports three operations: `replace` (the default), `insert_before`,
 //! and `insert_after`. Edits are batched per file via `check_overlaps`; edits
 //! within a file are applied bottom-to-top (sorted by `start` descending)

--- a/src/treesitter/parser.rs
+++ b/src/treesitter/parser.rs
@@ -101,7 +101,7 @@ impl ParserCache {
 
     /// Invalidate the cached tree for `path`.
     ///
-    /// The next call to [`parse_file`] will re-read and re-parse.
+    /// The next call to [`ParserCache::parse_file`] will re-read and re-parse.
     pub fn invalidate(&mut self, path: &Path) {
         let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
         self.cache.remove(&canonical);


### PR DESCRIPTION
## Summary
Fix 9 broken rustdoc intra-doc links across 4 files.

## Changes
- `src/hashing/state.rs`: `[get_anchors]` → `[AnchorState::get_anchors]`, `[notify_edit]` → `[AnchorState::notify_edit]`
- `src/llm/provider.rs`: `[LlmEvent]` → `[crate::llm::types::LlmEvent]` (2 occurrences), `[LlmStream]` → `[crate::llm::types::LlmStream]` (2 occurrences)
- `src/llm/types.rs`: `[LlmProvider::stream_chat]` → `[crate::llm::provider::LlmProvider::stream_chat]`
- `src/tools/edit.rs`: `[read_file]` → `[crate::tools::fs::ReadFileTool]`
- `src/treesitter/parser.rs`: `[parse_file]` → `[ParserCache::parse_file]`

Closes #122